### PR TITLE
Added rules for MySQL firewall #2 #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Unreleased
 
+- Added rule to check if allow access to Azure services enabled for MySQL. [#4](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/4)
+- Added rule to count the number of database server firewall rules for MySQL. [#2](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/2)
+
 ## v0.1.0-B190607 (pre-release)
 
 - Added rule documentation. [#40](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/40)

--- a/docs/rules/en-US/Azure.MySQL.AllowAzureAccess.md
+++ b/docs/rules/en-US/Azure.MySQL.AllowAzureAccess.md
@@ -1,0 +1,25 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.MySQL.AllowAzureAccess.md
+---
+
+# Azure.MySQL.AllowAzureAccess
+
+## SYNOPSIS
+
+Determine if access from Azure services is required.
+
+## DESCRIPTION
+
+Allow access to Azure services, permits any Azure service including other Azure customers, network based access to databases on the same MySQL server instance.
+
+If network based access is permitted, authentication is still required.
+
+Enabling access from Azure Services is useful in certain cases for on demand PaaS workloads where configuring a stable IP address is not possible. For example Azure Functions, Container Instances and Logic Apps.
+
+## RECOMMENDATION
+
+Where a stable IP addresses are able to be configured, configure IP or virtual network based firewall rules instead of using Allow access to Azure services.
+
+Determine if access from Azure services is required for the services connecting to the hosted databases.

--- a/docs/rules/en-US/Azure.MySQL.FirewallRuleCount.md
+++ b/docs/rules/en-US/Azure.MySQL.FirewallRuleCount.md
@@ -1,0 +1,19 @@
+---
+severity: Awareness
+category: Operations management
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.MySQL.FirewallRuleCount.md
+---
+
+# Azure.MySQL.FirewallRuleCount
+
+## SYNOPSIS
+
+Determine if there is an excessive number of firewall rules.
+
+## DESCRIPTION
+
+Typically number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+
+## RECOMMENDATION
+
+MySQL Server has greater then ten (10) firewall rules. Some rules may not be needed.

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -190,6 +190,45 @@ function VisitSqlServer {
     }
 }
 
+
+function VisitPostgreSqlServer {
+    param (
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+        [PSObject]$Resource,
+
+        [Parameter(Mandatory = $True)]
+        [Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer]$Context
+    )
+
+    process {
+        $sqlServer = $resource;
+        $resources = @();
+
+        # Get Postgre SQL Server firewall rules
+        $resources += Get-AzResource -Name $resource.Name -ResourceType 'Microsoft.DBforPostgreSQL/servers/firewallRules' -ResourceGroupName $resource.ResourceGroupName -DefaultProfile $Context -ApiVersion '2017-12-01' -ExpandProperties;
+        $sqlServer | Add-Member -MemberType NoteProperty -Name resources -Value $resources -PassThru;
+    }
+}
+
+function VisitMySqlServer {
+    param (
+        [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
+        [PSObject]$Resource,
+
+        [Parameter(Mandatory = $True)]
+        [Microsoft.Azure.Commands.Common.Authentication.Abstractions.Core.IAzureContextContainer]$Context
+    )
+
+    process {
+        $sqlServer = $resource;
+        $resources = @();
+
+        # Get MySQL Server firewall rules
+        $resources += Get-AzResource -Name $resource.Name -ResourceType 'Microsoft.DBforMySQL/servers/firewallRules' -ResourceGroupName $resource.ResourceGroupName -DefaultProfile $Context -ApiVersion '2017-12-01' -ExpandProperties;
+        $sqlServer | Add-Member -MemberType NoteProperty -Name resources -Value $resources -PassThru;
+    }
+}
+
 function VisitDataFactoryV2 {
     param (
         [Parameter(Mandatory = $True, ValueFromPipeline = $True)]
@@ -351,6 +390,8 @@ function ExpandResource {
     process {
         switch ($Resource.ResourceType) {
             "Microsoft.Sql/servers" { VisitSqlServer @PSBoundParameters; }
+            "Microsoft.DBforPostgreSQL/servers" { VisitPostgreSqlServer @PSBoundParameters; }
+            "Microsoft.DBforMySQL/servers" { VisitMySqlServer @PSBoundParameters; }
             "Microsoft.DataFactory/factories" { VisitDataFactoryV2 @PSBoundParameters; }
             # "Microsoft.Storage/storageAccounts" { VisitStorageAccount @PSBoundParameters; }
             # "Microsoft.StorageSync/storageSyncServices" { VisitStorageSyncService @PSBoundParameters; }

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -6,3 +6,25 @@
 Rule 'Azure.MySQL.UseSSL' -If { ResourceType 'Microsoft.DBforMySQL/servers' } -Tag @{ severity = 'Critical'; category = 'Security configuration' } {
     Within 'Properties.sslEnforcement' 'Enabled'
 }
+
+# Synopsis: Determine if there is an excessive number of firewall rules
+Rule 'Azure.MySQL.FirewallRuleCount' -If { ResourceType 'Microsoft.DBforMySQL/servers' } -Tag @{ severity = 'Awareness'; category = 'Operations management' } {
+    Hint 'SQL Server has > 10 firewall rules, some rules may not be needed';
+
+    $firewallRules = @($TargetObject.resources | Where-Object -FilterScript {
+        $_.Type -eq 'Microsoft.DBforMySQL/servers/firewallRules'
+    })
+    $firewallRules.Length -le 10;
+}
+
+# Synopsis: Determine if access from Azure services is required
+Rule 'Azure.MySQL.AllowAzureAccess' -If { ResourceType 'Microsoft.DBforMySQL/servers' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
+    $firewallRules = @($TargetObject.resources | Where-Object -FilterScript {
+        $_.Type -eq 'Microsoft.DBforMySQL/servers/firewallRules' -and
+        (
+            $_.ResourceName -eq 'AllowAllWindowsAzureIps' -or
+            ($_.properties.startIpAddress -eq '0.0.0.0' -and $_.properties.endIpAddress -eq '0.0.0.0')
+        )
+    })
+    $firewallRules.Length -eq 0;
+}

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -41,5 +41,37 @@ Describe 'Azure.MySQL' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-A';
         }
+
+        It 'Azure.MySQL.FirewallRuleCount' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.FirewallRuleCount' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
+
+        It 'Azure.MySQL.AllowAzureAccess' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.AllowAzureAccess' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
@@ -33,7 +33,141 @@
             "Capacity": 4
         },
         "Tags": null,
-        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000",
+        "resources": [
+            {
+                "ResourceName": "AllowAllWindowsAzureIps",
+                "Name": "AllowAllWindowsAzureIps",
+                "Properties": {
+                    "startIpAddress": "0.0.0.0",
+                    "endIpAddress": "0.0.0.0"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_1",
+                "Name": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_2",
+                "Name": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "10.1.2.1",
+                    "endIpAddress": "10.1.2.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_3",
+                "Name": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "10.1.3.1",
+                    "endIpAddress": "10.1.3.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_4",
+                "Name": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "10.1.4.1",
+                    "endIpAddress": "10.1.4.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_5",
+                "Name": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "10.1.5.1",
+                    "endIpAddress": "10.1.5.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_6",
+                "Name": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "10.1.6.1",
+                    "endIpAddress": "10.1.6.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_7",
+                "Name": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "10.1.7.1",
+                    "endIpAddress": "10.1.7.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_8",
+                "Name": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "10.1.8.1",
+                    "endIpAddress": "10.1.8.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_9",
+                "Name": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "10.1.9.1",
+                    "endIpAddress": "10.1.9.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            },
+            {
+                "ResourceName": "ClientIPAddress_10",
+                "Name": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "10.1.10.1",
+                    "endIpAddress": "10.1.10.1"
+                },
+                "ResourceGroupName": "test-rg",
+                "Type": "Microsoft.DBforMySQL/servers/firewallRules",
+                "ResourceType": "Microsoft.DBforMySQL/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+            }
+        ]
     },
     {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DBforMySQL/servers/server-A",

--- a/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
@@ -26,8 +26,8 @@ Describe 'Rule quality' {
         foreach ($rule in $result) {
             It $rule.RuleName {
                 $rule.Description | Should -Not -BeNullOrEmpty;
-                $rule.Tag.severity | Should -Not -BeNullOrEmpty;
-                $rule.Tag.category | Should -Not -BeNullOrEmpty;
+                $rule.Info.Annotations.severity | Should -Not -BeNullOrEmpty;
+                $rule.Info.Annotations.category | Should -Not -BeNullOrEmpty;
             }
         }
     }


### PR DESCRIPTION
## PR Summary

- Added rule to check if allow access to Azure services enabled for MySQL. #4
- Added rule to count the number of database server firewall rules for MySQL. #2

Fixes #4 
Fixes #2 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
