### PR TITLE
Added filtering by tag and resource group and fix AKS rule #60 #59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix rule `Azure.AKS.UseRBAC` returns null. [#60](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/60)
+
 ## v0.1.0
 
 - Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 
 - Fix rule `Azure.AKS.UseRBAC` returns null. [#60](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/60)
+- Added parameters to filter resource export by resource group and/ or tag. [#59](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/59)
+  - Added `-ResourceGroupName` and `-Tag` parameters to `Export-AzRuleData` cmdlet.
 
 ## v0.1.0
 

--- a/docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleData.md
+++ b/docs/commands/PSRule.Rules.Azure/en-US/Export-AzRuleData.md
@@ -16,14 +16,15 @@ Export resource configuration data from one or more Azure subscriptions.
 ### Default (Default)
 
 ```text
-Export-AzRuleData [[-OutputPath] <String>] [[-Subscription] <String[]>] [[-Tenant] <String[]>] [-PassThru]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-AzRuleData [[-OutputPath] <String>] [[-Subscription] <String[]>] [[-Tenant] <String[]>]
+ [-ResourceGroupName <String[]>] [-Tag <Hashtable>] [-PassThru] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### All
 
 ```text
-Export-AzRuleData [[-OutputPath] <String>] [-PassThru] [-All] [-WhatIf] [-Confirm] [<CommonParameters>]
+Export-AzRuleData [[-OutputPath] <String>] [-ResourceGroupName <String[]>] [-Tag <Hashtable>] [-PassThru]
+ [-All] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -91,6 +92,38 @@ Aliases:
 
 Required: False
 Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourceGroupName
+
+Optionally filter resources by Resource Group name.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+
+Optionally filter resources based on tag.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -20,5 +20,6 @@ Rule 'Azure.AKS.Version' -If { ResourceType 'Microsoft.ContainerService/managedC
 
 # Synopsis: AKS cluster should use role-based access control
 Rule 'Azure.AKS.UseRBAC' -If { ResourceType 'Microsoft.ContainerService/managedClusters' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
-    $TargetObject.Properties.enableRBAC
+    Exists 'Properties.enableRBAC'
+    $TargetObject.Properties.enableRBAC -eq $True
 }

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -163,6 +163,13 @@ Describe 'Export-AzRuleData' -Tag 'Cmdlet' {
             $result.Length | Should -Be 1;
             $result[0].Name | Should -Be 'Resource2'
         }
+
+        It '-Tag filter' {
+            $Null = Export-AzRuleData -Subscription 'Test subscription 1' -Tag @{ environment = 'production' } -PassThru;
+            Assert-MockCalled -CommandName 'GetAzureResource' -ModuleName 'PSRule.Rules.Azure' -Times 1 -ParameterFilter {
+                $Tag.environment -eq 'production'
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## PR Summary

- Fix rule `Azure.AKS.UseRBAC` returns null. #60
- Added parameters to filter resource export by resource group and/ or tag. #59
  - Added `-ResourceGroupName` and `-Tag` parameters to `Export-AzRuleData` cmdlet.

Fixes #60 
Fixes #59 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
