### PR TITLE
Fix rule Azure.Storage.SoftDelete returns null #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+- Fix rule `Azure.Storage.SoftDelete` and `Azure.Storage.SecureTransferRequired` returns null. [#64](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/64)
+
 ## v0.2.0-B190604 (pre-release)
 
 - Fix rule `Azure.AKS.UseRBAC` returns null. [#60](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/60)

--- a/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Storage.Rule.ps1
@@ -9,7 +9,7 @@ Rule 'Azure.Storage.UseReplication' -If { ResourceType 'Microsoft.Storage/storag
 
 # Synopsis: Storage accounts should only accept secure traffic
 Rule 'Azure.Storage.SecureTransferRequired' -If { ResourceType 'Microsoft.Storage/storageAccounts' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
-    $TargetObject.Properties.supportsHttpsTrafficOnly
+    $TargetObject.Properties.supportsHttpsTrafficOnly -eq $True
 }
 
 # Synopsis: Storage Service Encryption (SSE) should be enabled
@@ -17,7 +17,10 @@ Rule 'Azure.Storage.UseEncryption' -If { ResourceType 'Microsoft.Storage/storage
     ($Null -ne $TargetObject.Properties.encryption) -and
     ($Null -ne $TargetObject.Properties.encryption.services.blob) -and
     ($Null -ne $TargetObject.Properties.encryption.services.file) -and
-    ($TargetObject.Properties.encryption.services.blob.enabled -and $TargetObject.Properties.encryption.services.file.enabled)
+    (
+        ($TargetObject.Properties.encryption.services.blob.enabled -eq $True) -and
+        ($TargetObject.Properties.encryption.services.file.enabled -eq $True)
+    )
 }
 
 # Synopsis: Enable soft delete on Storage Accounts
@@ -25,5 +28,5 @@ Rule 'Azure.Storage.SoftDelete' -If { ResourceType 'Microsoft.Storage/storageAcc
     $serviceProperties = $TargetObject.resources | Where-Object -FilterScript {
         $_.ResourceType -eq 'serviceProperties'
     }
-    $serviceProperties.DeleteRetentionPolicy.Enabled
+    $serviceProperties.DeleteRetentionPolicy.Enabled -eq $True
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.ACR.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.ACR' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.ACR.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.ACR.AdminUser' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.ACR.AdminUser' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.AKS' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.AKS.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.AKS.MinNodeCount' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.MinNodeCount' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AppService.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.AppService' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.AppService.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.AppService.PlanInstanceCount' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AppService.PlanInstanceCount' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.DataFactory.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.DataFactory.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.DataFactory' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.DataFactory.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.DataFactory.Version' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.DataFactory.Version' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.MySQL' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.MySQL.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.MySQL.UseSSL' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.UseSSL' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.PostgreSQL' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.PostgreSQL.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.PostgreSQL.UseSSL' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.PostgreSQL.UseSSL' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PublicIP.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.PublicIP' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.PublicIP.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.PublicIP.IsAttached' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.PublicIP.IsAttached' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Redis.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.Redis' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.Redis.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.Redis.NonSslPort' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Redis.NonSslPort' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Azure.Resource' {
 
     Context 'Conditions' {
         $options = New-PSRuleOption -BaselineConfiguration @{ 'azureAllowedRegions' = @('region-A') };
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -Option $options -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -Option $options -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.Resource.UseTags' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Resource.UseTags' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.SQL' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.SQL.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.SQL.FirewallRuleCount' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SQL.FirewallRuleCount' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Storage.Tests.ps1
@@ -20,11 +20,11 @@ $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
-Describe 'Azure.Storage' {
+Describe 'Azure.Storage' -Tag Storage {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.Storage.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.Storage.UseReplication' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Storage.UseReplication' };
@@ -32,8 +32,8 @@ Describe 'Azure.Storage' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'storage-B', 'storage-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -48,8 +48,8 @@ Describe 'Azure.Storage' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -64,8 +64,8 @@ Describe 'Azure.Storage' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -80,8 +80,8 @@ Describe 'Azure.Storage' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'storage-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'storage-B', 'storage-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Subscription.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Subscription.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.Subscription' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.Subscription.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.Subscription.SecurityCenterContact' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Subscription.SecurityCenterContact' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualMachine.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualMachine.Tests.ps1
@@ -25,7 +25,7 @@ Describe 'Azure.VirtualMachine' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.VirtualMachine.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -Outcome All -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.VirtualMachine.UseManagedDisks' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualMachine.UseManagedDisks' };

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -24,7 +24,7 @@ Describe 'Azure.VirtualNetwork' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.VirtualNetwork.json';
 
     Context 'Conditions' {
-        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -Outcome All -WarningAction Ignore;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $dataPath -Outcome All -WarningAction Ignore -ErrorAction Stop;
 
         It 'Azure.VirtualNetwork.UseNSGs' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.UseNSGs' };

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Storage.json
@@ -153,5 +153,49 @@
                 "Type": "PSSeriviceProperties"
             }
         ]
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/storage-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Storage/storageAccounts/storage-C",
+        "Kind": "Storage",
+        "Location": "region",
+        "ResourceName": "storage-C",
+        "Name": "storage-C",
+        "Properties": {
+            "networkAcls": {
+                "bypass": "AzureServices",
+                "virtualNetworkRules": [],
+                "ipRules": [],
+                "defaultAction": "Allow"
+            },
+            "encryption": {
+                "services": {
+                    "file": {},
+                    "blob": {}
+                },
+                "keySource": "Microsoft.Storage"
+            },
+            "primaryEndpoints": {
+                "blob": "https://storage-C.blob.core.windows.net/",
+                "queue": "https://storage-C.queue.core.windows.net/",
+                "table": "https://storage-C.table.core.windows.net/",
+                "file": "https://storage-C.file.core.windows.net/"
+            },
+            "primaryLocation": "region",
+            "statusOfPrimary": "available"
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Storage/storageAccounts",
+        "ResourceType": "Microsoft.Storage/storageAccounts",
+        "Sku": {
+            "Name": "Standard_LRS",
+            "Tier": "Standard",
+            "Size": null,
+            "Family": null,
+            "Model": null,
+            "Capacity": null
+        },
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     }
 ]


### PR DESCRIPTION
## PR Summary

- Fix rule `Azure.Storage.SoftDelete` and `Azure.Storage.SecureTransferRequired` returns null. #64

Fixes #64 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
