### PR TITLE
Add SQL firewall rule range check #3 #10 #54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Unreleased
 
 - Fix rule `Azure.Storage.SoftDelete` and `Azure.Storage.SecureTransferRequired` returns null. [#64](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/64)
+- Added SQL firewall rule range check to determine an excessive number of permitted IP addresses. [#3](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/3) [#10](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/10) [#54](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/54)
+  - The rules `Azure.SQL.FirewallIPRange`, `Azure.MySQL.FirewallIPRange` and `Azure.PostgreSQL.FirewallIPRange` were added to check SQL, MySQL and PostgreSQL.
 
 ## v0.2.0-B190604 (pre-release)
 

--- a/docs/rules/en-US/Azure.MySQL.FirewallIPRange.md
+++ b/docs/rules/en-US/Azure.MySQL.FirewallIPRange.md
@@ -1,0 +1,19 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.MySQL.FirewallIPRange.md
+---
+
+# Azure.MySQL.FirewallIPRange
+
+## SYNOPSIS
+
+Determine if there is an excessive number of permitted IP addresses.
+
+## DESCRIPTION
+
+Typically the number of IP address rules permitted through the firewall is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+
+## RECOMMENDATION
+
+The MySQL server has greater then ten (10) public IP addresses that are permitted network access. Some rules may not be needed or can be reduced.

--- a/docs/rules/en-US/Azure.MySQL.FirewallRuleCount.md
+++ b/docs/rules/en-US/Azure.MySQL.FirewallRuleCount.md
@@ -12,8 +12,8 @@ Determine if there is an excessive number of firewall rules.
 
 ## DESCRIPTION
 
-Typically number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+Typically the number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
 
 ## RECOMMENDATION
 
-MySQL Server has greater then ten (10) firewall rules. Some rules may not be needed.
+The MySQL server has greater then ten (10) firewall rules. Some rules may not be needed.

--- a/docs/rules/en-US/Azure.PostgreSQL.FirewallIPRange.md
+++ b/docs/rules/en-US/Azure.PostgreSQL.FirewallIPRange.md
@@ -1,0 +1,19 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.PostgreSQL.FirewallIPRange.md
+---
+
+# Azure.PostgreSQL.FirewallIPRange
+
+## SYNOPSIS
+
+Determine if there is an excessive number of permitted IP addresses.
+
+## DESCRIPTION
+
+Typically the number of IP address rules permitted through the firewall is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+
+## RECOMMENDATION
+
+The PostgreSQL server has greater then ten (10) public IP addresses that are permitted network access. Some rules may not be needed or can be reduced.

--- a/docs/rules/en-US/Azure.PostgreSQL.FirewallRuleCount.md
+++ b/docs/rules/en-US/Azure.PostgreSQL.FirewallRuleCount.md
@@ -12,8 +12,8 @@ Determine if there is an excessive number of firewall rules.
 
 ## DESCRIPTION
 
-Typically number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+Typically the number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
 
 ## RECOMMENDATION
 
-PostgreSQL Server has greater then ten (10) firewall rules. Some rules may not be needed.
+The PostgreSQL server has greater then ten (10) firewall rules. Some rules may not be needed.

--- a/docs/rules/en-US/Azure.SQL.FirewallIPRange.md
+++ b/docs/rules/en-US/Azure.SQL.FirewallIPRange.md
@@ -1,0 +1,19 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.SQL.FirewallIPRange.md
+---
+
+# Azure.SQL.FirewallIPRange
+
+## SYNOPSIS
+
+Determine if there is an excessive number of permitted IP addresses.
+
+## DESCRIPTION
+
+Typically the number of IP address rules permitted through the firewall is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+
+## RECOMMENDATION
+
+SQL Server has greater then ten (10) public IP addresses that are permitted network access. Some rules may not be needed or can be reduced.

--- a/docs/rules/en-US/Azure.SQL.FirewallRuleCount.md
+++ b/docs/rules/en-US/Azure.SQL.FirewallRuleCount.md
@@ -12,8 +12,8 @@ Determine if there is an excessive number of firewall rules.
 
 ## DESCRIPTION
 
-Typically number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
+Typically the number of firewall rules required is minimal, with management connectivity from on-premises and cloud application connectivity the most common.
 
 ## RECOMMENDATION
 
-SQL Server has greater then ten (10) firewall rules. Some rules may not be needed.
+The logical SQL Server has greater then ten (10) firewall rules. Some rules may not be needed.

--- a/docs/rules/en-US/Azure.md
+++ b/docs/rules/en-US/Azure.md
@@ -15,9 +15,11 @@ RuleName | Description
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Use encrypted MySQL connections
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
 [Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required
+[Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
 [Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Use encrypted PostgreSQL connections
 [Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
 [Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required
+[Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
 [Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP addresses should be attached or cleaned up if not in use
 [Azure.Redis.NonSslPort](Azure.Redis.NonSslPort.md) | Redis Cache should only accept secure connections
 [Azure.Redis.MinTLS](Azure.Redis.MinTLS.md) | Redis Cache should reject TLS versions older then 1.2
@@ -25,6 +27,7 @@ RuleName | Description
 [Azure.Resource.AllowedRegions](Azure.Resource.AllowedRegions.md) | Resources should be deployed to allowed regions
 [Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
 [Azure.SQL.AllowAzureAccess](Azure.SQL.AllowAzureAccess.md) | Determine if access from Azure services is required
+[Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
 [Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable threat detection for Azure SQL logical server
 [Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server
 [Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using GRS may be at risk

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -180,9 +180,6 @@ task ModuleDependencies NuGet, PSRule, {
     if ($Null -eq (Get-InstalledModule -Name Az.Storage -MinimumVersion 1.3.0 -ErrorAction Ignore)) {
         Install-Module -Name Az.Storage -Scope CurrentUser -MinimumVersion 1.3.0 -Force -AllowClobber;
     }
-    if ($Null -eq (Get-InstalledModule -Name Az.Sql -MinimumVersion 1.9.0 -ErrorAction Ignore)) {
-        Install-Module -Name Az.Sql -Scope CurrentUser -MinimumVersion 1.9.0 -Force;
-    }
     if ($Null -eq (Get-InstalledModule -Name Az.Websites -MinimumVersion 1.2.1 -ErrorAction Ignore)) {
         Install-Module -Name Az.Websites -Scope CurrentUser -MinimumVersion 1.2.1 -Force;
     }

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psd1
@@ -54,7 +54,6 @@ RequiredModules = @(
     @{ ModuleName = 'Az.Resources'; ModuleVersion = '1.4.0' }
     @{ ModuleName = 'Az.Security'; ModuleVersion = '0.7.4' }
     @{ ModuleName = 'Az.Storage'; ModuleVersion = '1.3.0' }
-    @{ ModuleName = 'Az.Sql'; ModuleVersion = '1.9.0' }
     @{ ModuleName = 'Az.Websites'; ModuleVersion = '1.2.1' }
 )
 

--- a/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
+++ b/src/PSRule.Rules.Azure/PSRule.Rules.Azure.psm1
@@ -238,7 +238,7 @@ function VisitSqlServer {
         $resources = @();
 
         # Get SQL Server firewall rules
-        $resources += Get-AzSqlServerFirewallRule -ServerName $resource.Name -ResourceGroupName $resource.ResourceGroupName -DefaultProfile $Context | Add-Member -MemberType NoteProperty -Name 'type' -Value 'firewallRules' -PassThru;
+        $resources += Get-AzResource -Name $resource.Name -ResourceType 'Microsoft.SQL/servers/firewallRules' -ResourceGroupName $resource.ResourceGroupName -DefaultProfile $Context -ApiVersion '2014-04-01' -ExpandProperties;
         $sqlServer | Add-Member -MemberType NoteProperty -Name resources -Value $resources -PassThru;
     }
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.MySQL.Rule.ps1
@@ -28,3 +28,9 @@ Rule 'Azure.MySQL.AllowAzureAccess' -If { ResourceType 'Microsoft.DBforMySQL/ser
     })
     $firewallRules.Length -eq 0;
 }
+
+# Synopsis: Determine if there is an excessive number of permitted IP addresses
+Rule 'Azure.MySQL.FirewallIPRange' -If { ResourceType 'Microsoft.DBforMySQL/servers' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
+    $summary = GetIPAddressSummary
+    $summary.Public -le 10;
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.PostgreSQL.Rule.ps1
@@ -28,3 +28,9 @@ Rule 'Azure.PostgreSQL.AllowAzureAccess' -If { ResourceType 'Microsoft.DBforPost
     })
     $firewallRules.Length -eq 0;
 }
+
+# Synopsis: Determine if there is an excessive number of permitted IP addresses
+Rule 'Azure.PostgreSQL.FirewallIPRange' -If { ResourceType 'Microsoft.DBforPostgreSQL/servers' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
+    $summary = GetIPAddressSummary
+    $summary.Public -le 10;
+}

--- a/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.SQL.Rule.ps1
@@ -17,11 +17,17 @@ Rule 'Azure.SQL.AllowAzureAccess' -If { ResourceType 'Microsoft.Sql/servers' } -
     $firewallRules = @($TargetObject.resources | Where-Object -FilterScript {
         $_.Type -eq 'Microsoft.Sql/servers/firewallRules' -and
         (
-            $_.FirewallRuleName -eq 'AllowAllWindowsAzureIps' -or
-            ($_.StartIpAddress -eq '0.0.0.0' -and $_.EndIpAddress -eq '0.0.0.0')
+            $_.ResourceName -eq 'AllowAllWindowsAzureIps' -or
+            ($_.properties.StartIpAddress -eq '0.0.0.0' -and $_.properties.EndIpAddress -eq '0.0.0.0')
         )
     })
     $firewallRules.Length -eq 0;
+}
+
+# Synopsis: Determine if there is an excessive number of permitted IP addresses
+Rule 'Azure.SQL.FirewallIPRange' -If { ResourceType 'Microsoft.Sql/servers' } -Tag @{ severity = 'Important'; category = 'Security configuration' } {
+    $summary = GetIPAddressSummary
+    $summary.Public -le 10;
 }
 
 # Synopsis: Enable threat detection for Azure SQL logical server

--- a/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.MySQL.Tests.ps1
@@ -73,5 +73,21 @@ Describe 'Azure.MySQL' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-A';
         }
+
+        It 'Azure.MySQL.FirewallIPRange' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.MySQL.FirewallIPRange' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.PostgreSQL.Tests.ps1
@@ -73,5 +73,21 @@ Describe 'Azure.PostgreSQL' {
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'server-A';
         }
+
+        It 'Azure.PostgreSQL.FirewallIPRange' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.PostgreSQL.FirewallIPRange' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.SQL.Tests.ps1
@@ -58,6 +58,22 @@ Describe 'Azure.SQL' {
             $ruleResult.TargetName | Should -Be 'server-A';
         }
 
+        It 'Azure.SQL.FirewallIPRange' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SQL.FirewallIPRange' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'server-A';
+        }
+
         It 'Azure.SQL.ThreatDetection' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.SQL.ThreatDetection' };
 

--- a/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.MySQL.json
@@ -159,8 +159,8 @@
                 "ResourceName": "ClientIPAddress_10",
                 "Name": "ClientIPAddress_10",
                 "Properties": {
-                    "startIpAddress": "10.1.10.1",
-                    "endIpAddress": "10.1.10.1"
+                    "startIpAddress": "17.1.10.1",
+                    "endIpAddress": "17.1.10.255"
                 },
                 "ResourceGroupName": "test-rg",
                 "Type": "Microsoft.DBforMySQL/servers/firewallRules",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.PostgreSQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.PostgreSQL.json
@@ -159,8 +159,8 @@
                 "ResourceName": "ClientIPAddress_10",
                 "Name": "ClientIPAddress_10",
                 "Properties": {
-                    "startIpAddress": "10.1.10.1",
-                    "endIpAddress": "10.1.10.1"
+                    "startIpAddress": "17.1.10.1",
+                    "endIpAddress": "17.1.10.255"
                 },
                 "ResourceGroupName": "test-rg",
                 "Type": "Microsoft.DBforPostgreSQL/servers/firewallRules",

--- a/tests/PSRule.Rules.Azure.Tests/Resources.SQL.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.SQL.json
@@ -20,12 +20,16 @@
         },
         "resources": [
             {
+                "ResourceName": "ClientIPAddress_1",
+                "Name": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.1.0",
-                "EndIpAddress": "10.1.1.255",
-                "FirewallRuleName": "AllowSubnet",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
                 "type": "Microsoft.Sql/servers/auditingSettings",
@@ -73,92 +77,136 @@
         },
         "resources": [
             {
+                "ResourceName": "AllowAllWindowsAzureIps",
+                "Name": "AllowAllWindowsAzureIps",
+                "Properties": {
+                    "startIpAddress": "0.0.0.0",
+                    "endIpAddress": "0.0.0.0"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-B",
-                "StartIpAddress": "0.0.0.0",
-                "EndIpAddress": "0.0.0.0",
-                "FirewallRuleName": "AllowAllWindowsAzureIps",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_1",
+                "Name": "ClientIPAddress_1",
+                "Properties": {
+                    "startIpAddress": "10.1.1.1",
+                    "endIpAddress": "10.1.1.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.1.0",
-                "EndIpAddress": "10.1.1.255",
-                "FirewallRuleName": "AllowSubnet-A",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_2",
+                "Name": "ClientIPAddress_2",
+                "Properties": {
+                    "startIpAddress": "10.1.2.1",
+                    "endIpAddress": "10.1.2.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.2.0",
-                "EndIpAddress": "10.1.2.255",
-                "FirewallRuleName": "AllowSubnet-B",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_3",
+                "Name": "ClientIPAddress_3",
+                "Properties": {
+                    "startIpAddress": "10.1.3.1",
+                    "endIpAddress": "10.1.3.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.3.0",
-                "EndIpAddress": "10.1.3.255",
-                "FirewallRuleName": "AllowSubnet-C",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_4",
+                "Name": "ClientIPAddress_4",
+                "Properties": {
+                    "startIpAddress": "10.1.4.1",
+                    "endIpAddress": "10.1.4.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.4.0",
-                "EndIpAddress": "10.1.4.255",
-                "FirewallRuleName": "AllowSubnet-D",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_5",
+                "Name": "ClientIPAddress_5",
+                "Properties": {
+                    "startIpAddress": "10.1.5.1",
+                    "endIpAddress": "10.1.5.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.5.0",
-                "EndIpAddress": "10.1.5.255",
-                "FirewallRuleName": "AllowSubnet-E",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_6",
+                "Name": "ClientIPAddress_6",
+                "Properties": {
+                    "startIpAddress": "10.1.6.1",
+                    "endIpAddress": "10.1.6.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.6.0",
-                "EndIpAddress": "10.1.6.255",
-                "FirewallRuleName": "AllowSubnet-F",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_7",
+                "Name": "ClientIPAddress_7",
+                "Properties": {
+                    "startIpAddress": "10.1.7.1",
+                    "endIpAddress": "10.1.7.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.7.0",
-                "EndIpAddress": "10.1.7.255",
-                "FirewallRuleName": "AllowSubnet-G",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_8",
+                "Name": "ClientIPAddress_8",
+                "Properties": {
+                    "startIpAddress": "10.1.8.1",
+                    "endIpAddress": "10.1.8.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.8.0",
-                "EndIpAddress": "10.1.8.255",
-                "FirewallRuleName": "AllowSubnet-H",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_9",
+                "Name": "ClientIPAddress_9",
+                "Properties": {
+                    "startIpAddress": "10.1.9.1",
+                    "endIpAddress": "10.1.9.1"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.1.9.0",
-                "EndIpAddress": "10.1.9.255",
-                "FirewallRuleName": "AllowSubnet-I",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             },
             {
+                "ResourceName": "ClientIPAddress_10",
+                "Name": "ClientIPAddress_10",
+                "Properties": {
+                    "startIpAddress": "17.1.10.1",
+                    "endIpAddress": "17.1.10.255"
+                },
                 "ResourceGroupName": "test-rg",
-                "ServerName": "server-A",
-                "StartIpAddress": "10.0.0.0",
-                "EndIpAddress": "10.255.255.255",
-                "FirewallRuleName": "AllowSubnet",
-                "type": "Microsoft.Sql/servers/firewallRules"
+                "Type": "Microsoft.Sql/servers/firewallRules",
+                "ResourceType": "Microsoft.Sql/servers/firewallRules",
+                "SubscriptionId": "00000000-0000-0000-0000-000000000000"
             }
         ]
     },


### PR DESCRIPTION
## PR Summary

- Added SQL firewall rule range check to determine an excessive number of permitted IP addresses. #3 #10 #54
  - The rules `Azure.SQL.FirewallIPRange`, `Azure.MySQL.FirewallIPRange` and `Azure.PostgreSQL.FirewallIPRange` were added to check SQL, MySQL and PostgreSQL.

Fixes #3 
Fixes #10 
Fixes #54 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
