### PR TITLE
Added rules for AppGw and VNET DNS #68 #78

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,9 @@
         "**/.azure-pipelines/*.yaml": "azure-pipelines"
     },
     "cSpell.words": [
-        "cmdlet"
+        "OWASP",
+        "VNET",
+        "cmdlet",
+        "vnets"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 ## Unreleased
 
 - Added support for Application Gateway v2. [#75](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/75)
+- Added VNET rule to check for local DNS. [#68](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/68)
+- Added WAF hardening rules for Application Gateway. [#78](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/78)
+  - Application Gateways use OWASP 3.x rules.
+  - Application Gateways have WAF enabled.
+  - Application Gateways have all OWASP rules enabled.
 
 ## v0.2.0-B190706 (pre-release)
 

--- a/RuleToc.Doc.ps1
+++ b/RuleToc.Doc.ps1
@@ -2,7 +2,8 @@
 Document 'Azure' {
     Title 'Azure rules'
 
-    Get-PSRule -WarningAction SilentlyContinue | Table -Property @{ Name = 'RuleName'; Expression = {
+    Import-Module .\out\modules\PSRule.Rules.Azure
+    Get-PSRule -Module PSRule.Rules.Azure -WarningAction SilentlyContinue | Table -Property @{ Name = 'RuleName'; Expression = {
         "[$($_.RuleName)]($($_.RuleName).md)"
     }}, Description
 }

--- a/docs/rules/en-US/Azure.VirtualNetwork.AppGwOWASP.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.AppGwOWASP.md
@@ -1,0 +1,21 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.AppGwOWASP.md
+---
+
+# Azure.VirtualNetwork.AppGwOWASP
+
+## SYNOPSIS
+
+Application Gateway Web Application Firewall (WAF) should use OWASP 3.x rules.
+
+## DESCRIPTION
+
+Application Gateways deployed with WAF features support configuration of OWASP rule sets for detection and/ or prevention of malicious attacks.
+
+Two rule set versions are available; OWASP 2.x and OWASP 3.x.
+
+## RECOMMENDATION
+
+Consider configuring Application Gateway instances to use use newer OWASP 3.x rules instead of 2.x rule set versions.

--- a/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFEnabled.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFEnabled.md
@@ -1,0 +1,23 @@
+---
+severity: Critical
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFEnabled.md
+---
+
+# Azure.VirtualNetwork.AppGwWAFEnabled
+
+## SYNOPSIS
+
+Application Gateway Web Application Firewall (WAF) must be enabled to protect backend resources.
+
+## DESCRIPTION
+
+Security features of Application Gateways deployed with WAF may be toggled on or off.
+
+When WAF is disabled network traffic is still processed by the Application Gateway however detection and/ or prevention of malicious attacks does not occur.
+
+To protect backend resources from potentially malicious network traffic, WAF must be enabled.
+
+## RECOMMENDATION
+
+Consider enabling WAF for Application Gateway instances connected to un-trusted or low-trust networks such as the Internet.

--- a/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFRules.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFRules.md
@@ -1,0 +1,23 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.AppGwWAFRules.md
+---
+
+# Azure.VirtualNetwork.AppGwWAFRules
+
+## SYNOPSIS
+
+Application Gateway Web Application Firewall (WAF) should have all rules enabled.
+
+## DESCRIPTION
+
+Application Gateway instances with WAF allow OWASP detection/ prevention rules to be toggled on or off. All OWASP rules are turned on by default.
+
+When OWASP rules are turned off, the protection they provide is disabled.
+
+## RECOMMENDATION
+
+Consider enabling all OWASP rules within Application Gateway instances.
+
+Before disabling OWASP rules, ensure that the backend workload has alternative protections in-place. Alternatively consider updating application code to use safe web standards.

--- a/docs/rules/en-US/Azure.VirtualNetwork.LocalDNS.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.LocalDNS.md
@@ -1,0 +1,23 @@
+---
+severity: Important
+category: Reliability
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.LocalDNS.md
+---
+
+# Azure.VirtualNetwork.LocalDNS
+
+## SYNOPSIS
+
+Virtual networks (VNETs) should use Azure local DNS servers.
+
+## DESCRIPTION
+
+Virtual networks allow one or more custom DNS servers to be specified that are inherited by connected services such as virtual machines.
+
+When configuring custom DNS server IP addresses, these servers must be accessible for name resolution to occur. Connectivity between services may be impacted if DNS server IP addresses are temporarily or permanently unavailable.
+
+## RECOMMENDATION
+
+Consider deploying redundant DNS services within a connected Azure VNET.
+
+Where possibly consider deploying Azure Private DNS Zones, a platform-as-a-service (PaaS) DNS service for VNETs. Alternatively consider deploying redundant virtual machines (VMs) or network virtual appliances (NVA) to host DNS within Azure.

--- a/docs/rules/en-US/Azure.md
+++ b/docs/rules/en-US/Azure.md
@@ -2,55 +2,59 @@
 
 RuleName | Description
 -------- | -----------
-[Azure.ACR.AdminUser](Azure.ACR.AdminUser.md) | Use RBAC for delegating access to ACR instead of the registry admin user
-[Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments
-[Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates
-[Azure.AKS.Version](Azure.AKS.Version.md) | AKS cluster should meet the minimum version
-[Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | AKS cluster should use role-based access control
-[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | Use an App Service Plan with at least two (2) instances
-[Azure.AppService.MinPlan](Azure.AppService.MinPlan.md) | Use at least a Standard App Service Plan
-[Azure.AppService.ARRAffinity](Azure.AppService.ARRAffinity.md) | Disable client affinity for stateless services
-[Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Use HTTPS only
-[Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2
-[Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Use encrypted MySQL connections
-[Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
-[Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required
-[Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
-[Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Use encrypted PostgreSQL connections
-[Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
-[Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required
-[Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
-[Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP addresses should be attached or cleaned up if not in use
-[Azure.Redis.NonSslPort](Azure.Redis.NonSslPort.md) | Redis Cache should only accept secure connections
-[Azure.Redis.MinTLS](Azure.Redis.MinTLS.md) | Redis Cache should reject TLS versions older then 1.2
-[Azure.Resource.UseTags](Azure.Resource.UseTags.md) | Resources should be tagged
-[Azure.Resource.AllowedRegions](Azure.Resource.AllowedRegions.md) | Resources should be deployed to allowed regions
-[Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules
-[Azure.SQL.AllowAzureAccess](Azure.SQL.AllowAzureAccess.md) | Determine if access from Azure services is required
-[Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses
-[Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable threat detection for Azure SQL logical server
-[Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server
-[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using GRS may be at risk
-[Azure.Storage.SecureTransferRequired](Azure.Storage.SecureTransferRequired.md) | Storage accounts should only accept secure traffic
-[Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled
-[Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts
-[Azure.Subscription.SecurityCenterContact](Azure.Subscription.SecurityCenterContact.md) | Security Center email and phone contact details should be set
-[Azure.Subscription.SecurityCenterProvisioning](Azure.Subscription.SecurityCenterProvisioning.md) | Enable auto-provisioning on VMs to improve Security Center insights
-[Azure.VirtualMachine.UseManagedDisks](Azure.VirtualMachine.UseManagedDisks.md) | Virtual machines should use managed disks
-[Azure.VirtualMachine.Standalone](Azure.VirtualMachine.Standalone.md) | VMs much use premium disks or use availability sets/ zones to meet SLA requirements
-[Azure.VirtualMachine.DiskCaching](Azure.VirtualMachine.DiskCaching.md) | Check disk caching is configured correctly for the workload
-[Azure.VirtualMachine.UniqueDns](Azure.VirtualMachine.UniqueDns.md) | Network interfaces should inherit from virtual network
-[Azure.VirtualMachine.DiskAttached](Azure.VirtualMachine.DiskAttached.md) | Managed disks should be attached to virtual machines
-[Azure.VirtualMachine.DiskSizeAlignment](Azure.VirtualMachine.DiskSizeAlignment.md) | Managed disk is smaller than SKU size
-[Azure.VirtualMachine.UseHybridUseBenefit](Azure.VirtualMachine.UseHybridUseBenefit.md) | Use Hybrid Use Benefit
-[Azure.VirtualMachine.AcceleratedNetworking](Azure.VirtualMachine.AcceleratedNetworking.md) | Enabled accelerated networking for supported operating systems
-[Azure.VirtualMachine.ASAlignment](Azure.VirtualMachine.ASAlignment.md) | Availability sets should be aligned
-[Azure.VirtualMachine.ASMinMembers](Azure.VirtualMachine.ASMinMembers.md) | Availability sets should be deployed with at least two members
-[Azure.VirtualNetwork.UseNSGs](Azure.VirtualNetwork.UseNSGs.md) | Subnets should have NSGs assigned, except for the GatewaySubnet
-[Azure.VirtualNetwork.SingleDNS](Azure.VirtualNetwork.SingleDNS.md) | VNETs should have at least two DNS servers assigned
-[Azure.VirtualNetwork.NSGAnyInboundSource](Azure.VirtualNetwork.NSGAnyInboundSource.md) | Network security groups should avoid any inbound rules
-[Azure.VirtualNetwork.AppGwMinInstance](Azure.VirtualNetwork.AppGwMinInstance.md) | Application Gateway should use a minimum of two instances
-[Azure.VirtualNetwork.AppGwMinSku](Azure.VirtualNetwork.AppGwMinSku.md) | Application Gateway should use a minimum of Medium
-[Azure.VirtualNetwork.AppGwUseWAF](Azure.VirtualNetwork.AppGwUseWAF.md) | Internet accessible Application Gateways should use WAF
-[Azure.VirtualNetwork.AppGwSSLPolicy](Azure.VirtualNetwork.AppGwSSLPolicy.md) | Application Gateway should only accept a minimum of TLS 1.2
-[Azure.VirtualNetwork.AppGwPrevention](Azure.VirtualNetwork.AppGwPrevention.md) | Internet exposed Application Gateways should use prevention mode to protect backend resources
+[Azure.ACR.AdminUser](Azure.ACR.AdminUser.md) | Use Azure AD accounts instead of using the registry admin user.
+[Azure.ACR.MinSku](Azure.ACR.MinSku.md) | ACR should use the Premium or Standard SKU for production deployments.
+[Azure.AKS.MinNodeCount](Azure.AKS.MinNodeCount.md) | AKS clusters should have minimum number of nodes for failover and updates.
+[Azure.AKS.Version](Azure.AKS.Version.md) | AKS clusters should meet the minimum version.
+[Azure.AKS.UseRBAC](Azure.AKS.UseRBAC.md) | AKS cluster should use role-based access control (RBAC).
+[Azure.AppService.PlanInstanceCount](Azure.AppService.PlanInstanceCount.md) | Use an App Service Plan with at least two (2) instances.
+[Azure.AppService.MinPlan](Azure.AppService.MinPlan.md) | Use at least a Standard App Service Plan.
+[Azure.AppService.ARRAffinity](Azure.AppService.ARRAffinity.md) | Disable client affinity for stateless services.
+[Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Use HTTPS only. Disable HTTP when not required.
+[Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2.
+[Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections.
+[Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules.
+[Azure.MySQL.AllowAzureAccess](Azure.MySQL.AllowAzureAccess.md) | Determine if access from Azure services is required.
+[Azure.MySQL.FirewallIPRange](Azure.MySQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses.
+[Azure.PostgreSQL.UseSSL](Azure.PostgreSQL.UseSSL.md) | Enforce encrypted PostgreSQL connections.
+[Azure.PostgreSQL.FirewallRuleCount](Azure.PostgreSQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules.
+[Azure.PostgreSQL.AllowAzureAccess](Azure.PostgreSQL.AllowAzureAccess.md) | Determine if access from Azure services is required.
+[Azure.PostgreSQL.FirewallIPRange](Azure.PostgreSQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses.
+[Azure.PublicIP.IsAttached](Azure.PublicIP.IsAttached.md) | Public IP address should be attached.
+[Azure.Redis.NonSslPort](Azure.Redis.NonSslPort.md) | Redis Cache should only accept secure connections.
+[Azure.Redis.MinTLS](Azure.Redis.MinTLS.md) | Redis Cache should reject TLS versions older then 1.2.
+[Azure.Resource.UseTags](Azure.Resource.UseTags.md) | Resources should be tagged.
+[Azure.Resource.AllowedRegions](Azure.Resource.AllowedRegions.md) | Resources should be deployed to allowed regions.
+[Azure.SQL.FirewallRuleCount](Azure.SQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules.
+[Azure.SQL.AllowAzureAccess](Azure.SQL.AllowAzureAccess.md) | Determine if access from Azure services is required.
+[Azure.SQL.FirewallIPRange](Azure.SQL.FirewallIPRange.md) | Determine if there is an excessive number of permitted IP addresses.
+[Azure.SQL.ThreatDetection](Azure.SQL.ThreatDetection.md) | Enable threat detection for Azure SQL logical server.
+[Azure.SQL.Auditing](Azure.SQL.Auditing.md) | Enable auditing for Azure SQL logical server.
+[Azure.Storage.UseReplication](Azure.Storage.UseReplication.md) | Storage accounts not using GRS may be at risk.
+[Azure.Storage.SecureTransferRequired](Azure.Storage.SecureTransferRequired.md) | Storage accounts should only accept secure traffic.
+[Azure.Storage.UseEncryption](Azure.Storage.UseEncryption.md) | Storage Service Encryption (SSE) should be enabled.
+[Azure.Storage.SoftDelete](Azure.Storage.SoftDelete.md) | Enable soft delete on Storage Accounts.
+[Azure.Subscription.SecurityCenterContact](Azure.Subscription.SecurityCenterContact.md) | Security Center email and phone contact details should be set.
+[Azure.Subscription.SecurityCenterProvisioning](Azure.Subscription.SecurityCenterProvisioning.md) | Enable auto-provisioning on VMs to improve Security Center insights.
+[Azure.VirtualMachine.UseManagedDisks](Azure.VirtualMachine.UseManagedDisks.md) | Virtual machines should use managed disks.
+[Azure.VirtualMachine.Standalone](Azure.VirtualMachine.Standalone.md) | VMs much use premium disks or use availability sets/ zones to meet SLA requirements.
+[Azure.VirtualMachine.DiskCaching](Azure.VirtualMachine.DiskCaching.md) | Check disk caching is configured correctly for the workload.
+[Azure.VirtualMachine.UniqueDns](Azure.VirtualMachine.UniqueDns.md) | Network interfaces should inherit from virtual network.
+[Azure.VirtualMachine.DiskAttached](Azure.VirtualMachine.DiskAttached.md) | Managed disks should be attached to virtual machines.
+[Azure.VirtualMachine.DiskSizeAlignment](Azure.VirtualMachine.DiskSizeAlignment.md) | Managed disk is smaller than SKU size.
+[Azure.VirtualMachine.UseHybridUseBenefit](Azure.VirtualMachine.UseHybridUseBenefit.md) | Use Hybrid Use Benefit.
+[Azure.VirtualMachine.AcceleratedNetworking](Azure.VirtualMachine.AcceleratedNetworking.md) | Enabled accelerated networking for supported operating systems.
+[Azure.VirtualMachine.ASAlignment](Azure.VirtualMachine.ASAlignment.md) | Availability sets should be aligned.
+[Azure.VirtualMachine.ASMinMembers](Azure.VirtualMachine.ASMinMembers.md) | Availability sets should be deployed with at least two members.
+[Azure.VirtualNetwork.UseNSGs](Azure.VirtualNetwork.UseNSGs.md) | Subnets should have NSGs assigned.
+[Azure.VirtualNetwork.SingleDNS](Azure.VirtualNetwork.SingleDNS.md) | VNETs should have at least two DNS servers assigned.
+[Azure.VirtualNetwork.LocalDNS](Azure.VirtualNetwork.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers.
+[Azure.VirtualNetwork.NSGAnyInboundSource](Azure.VirtualNetwork.NSGAnyInboundSource.md) | Network security groups should avoid any inbound rules.
+[Azure.VirtualNetwork.AppGwMinInstance](Azure.VirtualNetwork.AppGwMinInstance.md) | Application Gateways should use a minimum of two instances.
+[Azure.VirtualNetwork.AppGwMinSku](Azure.VirtualNetwork.AppGwMinSku.md) | Application Gateway should use a minimum instance size of Medium.
+[Azure.VirtualNetwork.AppGwUseWAF](Azure.VirtualNetwork.AppGwUseWAF.md) | Internet accessible Application Gateways should use WAF.
+[Azure.VirtualNetwork.AppGwSSLPolicy](Azure.VirtualNetwork.AppGwSSLPolicy.md) | Application Gateway should only accept a minimum of TLS 1.2.
+[Azure.VirtualNetwork.AppGwPrevention](Azure.VirtualNetwork.AppGwPrevention.md) | Internet exposed Application Gateways should use prevention mode to protect backend resources.
+[Azure.VirtualNetwork.AppGwWAFEnabled](Azure.VirtualNetwork.AppGwWAFEnabled.md) | Application Gateway Web Application Firewall (WAF) must be enabled to protect backend resources.
+[Azure.VirtualNetwork.AppGwOWASP](Azure.VirtualNetwork.AppGwOWASP.md) | Application Gateway Web Application Firewall (WAF) should use OWASP 3.x rules.
+[Azure.VirtualNetwork.AppGwWAFRules](Azure.VirtualNetwork.AppGwWAFRules.md) | Application Gateway Web Application Firewall (WAF) should have all rules enabled.

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -20,7 +20,7 @@ $rootPath = $PWD;
 Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule.Rules.Azure) -Force;
 $here = (Resolve-Path $PSScriptRoot).Path;
 
-Describe 'Azure.VirtualNetwork' {
+Describe 'Azure.VirtualNetwork' -Tag 'Network' {
     $dataPath = Join-Path -Path $here -ChildPath 'Resources.VirtualNetwork.json';
 
     Context 'Conditions' {
@@ -44,6 +44,22 @@ Describe 'Azure.VirtualNetwork' {
 
         It 'Azure.VirtualNetwork.SingleDNS' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.SingleDNS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-A';
+        }
+
+        It 'Azure.VirtualNetwork.LocalDNS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.LocalDNS' };
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
@@ -152,6 +168,54 @@ Describe 'Azure.VirtualNetwork' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
             $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C';
+        }
+
+        It 'Azure.VirtualNetwork.AppGwWAFEnabled' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.AppGwWAFEnabled' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgw-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'appgw-A', 'appgw-C';
+        }
+
+        It 'Azure.VirtualNetwork.AppGwOWASP' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.AppGwOWASP' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgw-A';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgw-C';
+        }
+
+        It 'Azure.VirtualNetwork.AppGwWAFRules' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.AppGwWAFRules' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgw-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'appgw-A';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -164,7 +164,7 @@
             },
             "dhcpOptions": {
                 "dnsServers": [
-                    "10.2.0.36"
+                    "10.99.0.36"
                 ]
             },
             "subnets": [
@@ -863,7 +863,7 @@
                 "enabled": true,
                 "firewallMode": "Prevention",
                 "ruleSetType": "OWASP",
-                "ruleSetVersion": "3.0",
+                "ruleSetVersion": "2.2.9",
                 "disabledRuleGroups": [],
                 "requestBodyCheck": true,
                 "maxRequestBodySizeInKb": 128,
@@ -1019,7 +1019,7 @@
             "rewriteRuleSets": [],
             "redirectConfigurations": [],
             "webApplicationFirewallConfiguration": {
-                "enabled": true,
+                "enabled": false,
                 "firewallMode": "Detection",
                 "ruleSetType": "OWASP",
                 "ruleSetVersion": "3.0",
@@ -1044,228 +1044,228 @@
         "ResourceName": "appgw-C",
         "Name": "appgw-C",
         "Properties": {
-          "provisioningState": "Succeeded",
-          "sku": {
-            "name": "WAF_v2",
-            "tier": "WAF_v2"
-          },
-          "operationalState": "Running",
-          "gatewayIPConfigurations": [
-            {
-              "name": "appGatewayIpConfig",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/gatewayIPConfigurations/appGatewayIpConfig",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "subnet": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-aks/providers/Microsoft.Network/virtualNetworks/service-int-eus-vnet/subnets/appgw"
-                }
-              },
-              "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"
-            }
-          ],
-          "sslCertificates": [],
-          "trustedRootCertificates": [],
-          "frontendIPConfigurations": [
-            {
-              "name": "appGwPublicFrontendIp",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendIPConfigurations/appGwPublicFrontendIp",
-              "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "privateIPAllocationMethod": "Dynamic",
-                "publicIPAddress": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/app-gw-ip"
-                },
-                "httpListeners": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
-                  }
-                ]
-              }
-            }
-          ],
-          "frontendPorts": [
-            {
-              "name": "port_80",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendPorts/port_80",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "port": 80,
-                "httpListeners": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
-                  }
-                ]
-              },
-              "type": "Microsoft.Network/applicationGateways/frontendPorts"
-            }
-          ],
-          "backendAddressPools": [
-            {
-              "name": "backend",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendAddressPools/backend",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "backendAddresses": [
-                  {
-                    "fqdn": "website-A.azurewebsites.net"
-                  }
-                ],
-                "requestRoutingRules": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
-                  }
-                ]
-              },
-              "type": "Microsoft.Network/applicationGateways/backendAddressPools"
-            }
-          ],
-          "backendHttpSettingsCollection": [
-            {
-              "name": "http-settings",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "port": 80,
-                "protocol": "Http",
-                "cookieBasedAffinity": "Enabled",
-                "pickHostNameFromBackendAddress": true,
-                "affinityCookieName": "ApplicationGatewayAffinity",
-                "path": null,
-                "requestTimeout": 20,
-                "probe": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b"
-                },
-                "requestRoutingRules": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
-                  }
-                ]
-              },
-              "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"
-            }
-          ],
-          "httpListeners": [
-            {
-              "name": "http-listener",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "frontendIPConfiguration": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendIPConfigurations/appGwPublicFrontendIp"
-                },
-                "frontendPort": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendPorts/port_80"
-                },
-                "protocol": "Http",
-                "requireServerNameIndication": false,
-                "requestRoutingRules": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
-                  }
-                ]
-              },
-              "type": "Microsoft.Network/applicationGateways/httpListeners"
-            }
-          ],
-          "urlPathMaps": [],
-          "requestRoutingRules": [
-            {
-              "name": "http-rule",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "ruleType": "Basic",
-                "httpListener": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
-                },
-                "backendAddressPool": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendAddressPools/backend"
-                },
-                "backendHttpSettings": {
-                  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings"
-                }
-              },
-              "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
-            }
-          ],
-          "probes": [
-            {
-              "name": "http-probe",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-probe",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "protocol": "Http",
-                "host": "localhost",
-                "path": "/",
-                "interval": 30,
-                "timeout": 30,
-                "unhealthyThreshold": 3,
-                "pickHostNameFromBackendHttpSettings": false,
-                "minServers": 0,
-                "match": {
-                  "body": "",
-                  "statusCodes": [
-                    "200-399"
-                  ]
-                }
-              },
-              "type": "Microsoft.Network/applicationGateways/probes"
+            "provisioningState": "Succeeded",
+            "sku": {
+                "name": "WAF_v2",
+                "tier": "WAF_v2"
             },
-            {
-              "name": "http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b",
-              "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b",
-              "properties": {
-                "provisioningState": "Succeeded",
-                "protocol": "Http",
-                "path": "/",
-                "interval": 30,
-                "timeout": 30,
-                "unhealthyThreshold": 3,
-                "pickHostNameFromBackendHttpSettings": true,
-                "minServers": 0,
-                "match": {
-                  "body": "",
-                  "statusCodes": [
-                    "200-399"
-                  ]
-                },
-                "backendHttpSettings": [
-                  {
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings"
-                  }
-                ]
-              },
-              "type": "Microsoft.Network/applicationGateways/probes"
-            }
-          ],
-          "rewriteRuleSets": [],
-          "redirectConfigurations": [],
-          "webApplicationFirewallConfiguration": {
-            "enabled": true,
-            "firewallMode": "Prevention",
-            "ruleSetType": "OWASP",
-            "ruleSetVersion": "3.0",
-            "disabledRuleGroups": [
-              {
-                "ruleGroupName": "REQUEST-921-PROTOCOL-ATTACK"
-              }
+            "operationalState": "Running",
+            "gatewayIPConfigurations": [
+                {
+                    "name": "appGatewayIpConfig",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/gatewayIPConfigurations/appGatewayIpConfig",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "subnet": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/service-aks/providers/Microsoft.Network/virtualNetworks/service-int-eus-vnet/subnets/appgw"
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"
+                }
             ],
-            "exclusions": [],
-            "requestBodyCheck": true,
-            "maxRequestBodySizeInKb": 128,
-            "fileUploadLimitInMb": 100
-          },
-          "enableHttp2": false,
-          "autoscaleConfiguration": {
-            "minCapacity": 2,
-            "maxCapacity": 3
-          }
+            "sslCertificates": [],
+            "trustedRootCertificates": [],
+            "frontendIPConfigurations": [
+                {
+                    "name": "appGwPublicFrontendIp",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendIPConfigurations/appGwPublicFrontendIp",
+                    "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "privateIPAllocationMethod": "Dynamic",
+                        "publicIPAddress": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/app-gw-ip"
+                        },
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
+                            }
+                        ]
+                    }
+                }
+            ],
+            "frontendPorts": [
+                {
+                    "name": "port_80",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendPorts/port_80",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "port": 80,
+                        "httpListeners": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/frontendPorts"
+                }
+            ],
+            "backendAddressPools": [
+                {
+                    "name": "backend",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendAddressPools/backend",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "backendAddresses": [
+                            {
+                                "fqdn": "website-A.azurewebsites.net"
+                            }
+                        ],
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/backendAddressPools"
+                }
+            ],
+            "backendHttpSettingsCollection": [
+                {
+                    "name": "http-settings",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "port": 80,
+                        "protocol": "Http",
+                        "cookieBasedAffinity": "Enabled",
+                        "pickHostNameFromBackendAddress": true,
+                        "affinityCookieName": "ApplicationGatewayAffinity",
+                        "path": null,
+                        "requestTimeout": 20,
+                        "probe": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b"
+                        },
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"
+                }
+            ],
+            "httpListeners": [
+                {
+                    "name": "http-listener",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "frontendIPConfiguration": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendIPConfigurations/appGwPublicFrontendIp"
+                        },
+                        "frontendPort": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/frontendPorts/port_80"
+                        },
+                        "protocol": "Http",
+                        "requireServerNameIndication": false,
+                        "requestRoutingRules": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/httpListeners"
+                }
+            ],
+            "urlPathMaps": [],
+            "requestRoutingRules": [
+                {
+                    "name": "http-rule",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/requestRoutingRules/http-rule",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "ruleType": "Basic",
+                        "httpListener": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/httpListeners/http-listener"
+                        },
+                        "backendAddressPool": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendAddressPools/backend"
+                        },
+                        "backendHttpSettings": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings"
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
+                }
+            ],
+            "probes": [
+                {
+                    "name": "http-probe",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-probe",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "protocol": "Http",
+                        "host": "localhost",
+                        "path": "/",
+                        "interval": 30,
+                        "timeout": 30,
+                        "unhealthyThreshold": 3,
+                        "pickHostNameFromBackendHttpSettings": false,
+                        "minServers": 0,
+                        "match": {
+                            "body": "",
+                            "statusCodes": [
+                                "200-399"
+                            ]
+                        }
+                    },
+                    "type": "Microsoft.Network/applicationGateways/probes"
+                },
+                {
+                    "name": "http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/probes/http-settings3fb94afb-03a0-4169-a8c7-64a8cc5e001b",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "protocol": "Http",
+                        "path": "/",
+                        "interval": 30,
+                        "timeout": 30,
+                        "unhealthyThreshold": 3,
+                        "pickHostNameFromBackendHttpSettings": true,
+                        "minServers": 0,
+                        "match": {
+                            "body": "",
+                            "statusCodes": [
+                                "200-399"
+                            ]
+                        },
+                        "backendHttpSettings": [
+                            {
+                                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-C/backendHttpSettingsCollection/http-settings"
+                            }
+                        ]
+                    },
+                    "type": "Microsoft.Network/applicationGateways/probes"
+                }
+            ],
+            "rewriteRuleSets": [],
+            "redirectConfigurations": [],
+            "webApplicationFirewallConfiguration": {
+                "enabled": true,
+                "firewallMode": "Prevention",
+                "ruleSetType": "OWASP",
+                "ruleSetVersion": "3.0",
+                "disabledRuleGroups": [
+                    {
+                        "ruleGroupName": "REQUEST-921-PROTOCOL-ATTACK"
+                    }
+                ],
+                "exclusions": [],
+                "requestBodyCheck": true,
+                "maxRequestBodySizeInKb": 128,
+                "fileUploadLimitInMb": 100
+            },
+            "enableHttp2": false,
+            "autoscaleConfiguration": {
+                "minCapacity": 2,
+                "maxCapacity": 3
+            }
         },
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Network/applicationGateways",
         "ResourceType": "Microsoft.Network/applicationGateways",
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
-      }
+    }
 ]


### PR DESCRIPTION
## PR Summary

- Added VNET rule to check for local DNS. #68
- Added WAF hardening rules for Application Gateway. #78
  - Application Gateways use OWASP 3.x rules.
  - Application Gateways have WAF enabled.
  - Application Gateways have all OWASP rules enabled.

Fixes #68 
Fixes #78 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
