### PR TITLE
Fix handling of empty DNS servers #84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Updated AKS version in `Azure.AKS.Version` to 1.13.7. [#83](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/83)
+- Fix handling of empty DNS servers in `Azure.VirtualNetwork.LocalDNS`. [#84](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/84)
 
 ## v0.2.0
 

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -22,7 +22,7 @@ Rule 'Azure.VirtualNetwork.UseNSGs' -If { ResourceType 'Microsoft.Network/virtua
 # Synopsis: VNETs should have at least two DNS servers assigned
 Rule 'Azure.VirtualNetwork.SingleDNS'  -If { ResourceType 'Microsoft.Network/virtualNetworks' } -Tag @{ severity = 'Single point of failure'; category = 'Reliability' } {
     # If DNS servers are customsied, at least two IP addresses should be defined
-    if (!(Exists 'properties.dhcpOptions.dnsServers')) {
+    if (!(Exists 'properties.dhcpOptions.dnsServers') -or ($TargetObject.properties.dhcpOptions.dnsServers.Count -eq 0)) {
         $True;
     }
     else {
@@ -32,7 +32,7 @@ Rule 'Azure.VirtualNetwork.SingleDNS'  -If { ResourceType 'Microsoft.Network/vir
 
 # Synopsis: VNETs should use Azure local DNS servers
 Rule 'Azure.VirtualNetwork.LocalDNS' -If { ResourceType 'Microsoft.Network/virtualNetworks' } {
-    if (!(Exists 'properties.dhcpOptions.dnsServers')) {
+    if (!(Exists 'properties.dhcpOptions.dnsServers') -or ($TargetObject.properties.dhcpOptions.dnsServers.Count -eq 0)) {
         $True;
     }
     else {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -32,8 +32,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-C';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -54,8 +54,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C';
         }
 
         It 'Azure.VirtualNetwork.LocalDNS' {
@@ -70,8 +70,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-A';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C';
         }
 
         It 'Azure.VirtualNetwork.NSGAnyInboundSource' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -170,7 +170,7 @@
             "subnets": [
                 {
                     "name": "GatewaySubnet",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/GatewaySubnet",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/subnets/GatewaySubnet",
                     "properties": {
                         "addressPrefix": "10.2.0.0/27",
                         "serviceEndpoints": [],
@@ -180,7 +180,7 @@
                 },
                 {
                     "name": "subnet-A",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/subnets/subnet-A",
                     "properties": {
                         "addressPrefix": "10.2.0.32/28",
                         "networkSecurityGroup": {
@@ -196,7 +196,7 @@
                 },
                 {
                     "name": "subnet-B",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-B",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/subnets/subnet-B",
                     "properties": {
                         "addressPrefix": "10.2.0.48/28",
                         "routeTable": {
@@ -209,7 +209,7 @@
                 },
                 {
                     "name": "subnet-C",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-C",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/subnets/subnet-C",
                     "properties": {
                         "addressPrefix": "10.2.0.64/28",
                         "networkSecurityGroup": null,
@@ -223,7 +223,7 @@
                 },
                 {
                     "name": "subnet-D",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-D",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/subnets/subnet-D",
                     "properties": {
                         "addressPrefix": "10.2.0.80/28",
                         "networkSecurityGroup": {},
@@ -239,7 +239,124 @@
             "virtualNetworkPeerings": [
                 {
                     "name": "peer-A",
-                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/virtualNetworkPeerings/peer-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-B/virtualNetworkPeerings/peer-A",
+                    "properties": {
+                        "peeringState": "Connected",
+                        "remoteVirtualNetwork": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A"
+                        },
+                        "allowVirtualNetworkAc2cess": true,
+                        "allowForwardedTraffic": false,
+                        "allowGatewayTransit": false,
+                        "useRemoteGateways": false,
+                        "doNotVerifyRemoteGateways": false,
+                        "remoteAddressSpace": {
+                            "addressPrefixes": [
+                                "10.1.0.0/24"
+                            ]
+                        },
+                        "routeServiceVips": {}
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings"
+                }
+            ],
+            "enableDdosProtection": false,
+            "enableVmProtection": false
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/virtualNetworks",
+        "ResourceType": "Microsoft.Network/virtualNetworks",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C",
+        "Location": "region",
+        "ResourceName": "vnet-C",
+        "Name": "vnet-C",
+        "Properties": {
+            "addressSpace": {
+                "addressPrefixes": [
+                    "10.3.0.0/24"
+                ]
+            },
+            "dhcpOptions": {
+                "dnsServers": []
+            },
+            "subnets": [
+                {
+                    "name": "GatewaySubnet",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/GatewaySubnet",
+                    "properties": {
+                        "addressPrefix": "10.3.0.0/27",
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/subnet-A",
+                    "properties": {
+                        "addressPrefix": "10.3.0.32/28",
+                        "networkSecurityGroup": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A"
+                        },
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-B",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/subnet-B",
+                    "properties": {
+                        "addressPrefix": "10.3.0.48/28",
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-C",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/subnet-C",
+                    "properties": {
+                        "addressPrefix": "10.3.0.64/28",
+                        "networkSecurityGroup": null,
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-D",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/subnets/subnet-D",
+                    "properties": {
+                        "addressPrefix": "10.3.0.80/28",
+                        "networkSecurityGroup": {},
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                }
+            ],
+            "virtualNetworkPeerings": [
+                {
+                    "name": "peer-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-C/virtualNetworkPeerings/peer-A",
                     "properties": {
                         "peeringState": "Connected",
                         "remoteVirtualNetwork": {


### PR DESCRIPTION
## PR Summary

- Fix handling of empty DNS servers in `Azure.VirtualNetwork.LocalDNS`. #84 

Fixes #84 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
