### PR TITLE
Fix handling of peering in Azure.VirtualNetwork.LocalDNS #89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - Updated AKS version in `Azure.AKS.Version` to 1.13.7. [#83](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/83)
 - Fix handling of empty DNS servers in `Azure.VirtualNetwork.LocalDNS`. [#84](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/84)
+- Fix handling of no peering connections in `Azure.VirtualNetwork.LocalDNS`. [#89](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/89)
 
 ## v0.2.0
 

--- a/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.VirtualNetwork.Rule.ps1
@@ -41,7 +41,9 @@ Rule 'Azure.VirtualNetwork.LocalDNS' -If { ResourceType 'Microsoft.Network/virtu
         $primary = $dnsServers[0]
         $localRanges = @();
         $localRanges += $TargetObject.Properties.addressSpace.addressPrefixes
-        $localRanges += $TargetObject.Properties.virtualNetworkPeerings.properties.remoteAddressSpace.addressPrefixes
+        if ($Null -ne $TargetObject.Properties.virtualNetworkPeerings -and $TargetObject.Properties.virtualNetworkPeerings.Length -gt 0) {
+            $localRanges += $TargetObject.Properties.virtualNetworkPeerings.properties.remoteAddressSpace.addressPrefixes
+        }
 
         # Determine if the primary is in range
         WithinCIDR -IP $primary -CIDR $localRanges

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -32,8 +32,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-C', 'vnet-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
@@ -54,8 +54,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -Be 'vnet-A', 'vnet-C', 'vnet-D';
         }
 
         It 'Azure.VirtualNetwork.LocalDNS' {
@@ -64,8 +64,8 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-B';
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-D';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -387,6 +387,103 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D",
+        "Location": "region",
+        "ResourceName": "vnet-D",
+        "Name": "vnet-D",
+        "Properties": {
+            "addressSpace": {
+                "addressPrefixes": [
+                    "10.4.0.0/24"
+                ]
+            },
+            "dhcpOptions": {
+                "dnsServers": [
+                    "10.99.0.36",
+                    "10.99.0.37"
+                ]
+            },
+            "subnets": [
+                {
+                    "name": "GatewaySubnet",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D/subnets/GatewaySubnet",
+                    "properties": {
+                        "addressPrefix": "10.4.0.0/27",
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-A",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D/subnets/subnet-A",
+                    "properties": {
+                        "addressPrefix": "10.4.0.32/28",
+                        "networkSecurityGroup": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A"
+                        },
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-B",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D/subnets/subnet-B",
+                    "properties": {
+                        "addressPrefix": "10.4.0.48/28",
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-C",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D/subnets/subnet-C",
+                    "properties": {
+                        "addressPrefix": "10.4.0.64/28",
+                        "networkSecurityGroup": null,
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                },
+                {
+                    "name": "subnet-D",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-D/subnets/subnet-D",
+                    "properties": {
+                        "addressPrefix": "10.4.0.80/28",
+                        "networkSecurityGroup": {},
+                        "routeTable": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/routeTables/route-A"
+                        },
+                        "serviceEndpoints": [],
+                        "delegations": []
+                    },
+                    "type": "Microsoft.Network/virtualNetworks/subnets"
+                }
+            ],
+            "virtualNetworkPeerings": [],
+            "enableDdosProtection": false,
+            "enableVmProtection": false
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/virtualNetworks",
+        "ResourceType": "Microsoft.Network/virtualNetworks",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-A",
         "Location": "region",


### PR DESCRIPTION
## PR Summary

- Fix handling of no peering connections in `Azure.VirtualNetwork.LocalDNS`. #89 

Fixes #89 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
