### PR TITLE
Pre-release v0.3.0-B190710

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## Unreleased
 
+## v0.3.0-B190710 (pre-release)
+
 - Fix handling of empty DNS servers in `Azure.VirtualNetwork.LocalDNS`. [#84](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/84)
 - Fix handling of no peering connections in `Azure.VirtualNetwork.LocalDNS`. [#89](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/89)
 - Updated AKS version in `Azure.AKS.Version` to 1.13.7. [#83](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/83)


### PR DESCRIPTION
## PR Summary

- Fix handling of empty DNS servers in `Azure.VirtualNetwork.LocalDNS`. #84
- Fix handling of no peering connections in `Azure.VirtualNetwork.LocalDNS`. #89
- Updated AKS version in `Azure.AKS.Version` to 1.13.7. #83
- Added VM SKU rules:
  - VMs should avoid using expired promo SKUs. #87
  - VMs should avoid using basic SKUs. #69

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
