### PR TITLE
Deny all inbound NSG rule #94 #93 #92 #103

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,15 +19,29 @@
     },
     "cSpell.words": [
         "Kubernetes",
+        "NSGs",
         "OWASP",
         "RBAC",
         "SKUs",
         "VNET",
+        "VNETs",
         "cmdlet",
         "cmdlets",
-        "NSGs",
+        "endregion",
+        "lifecycle",
+        "nics",
+        "stateful",
         "subnet",
-        "subnets",
-        "VNETs"
+        "subnets"
+    ],
+    "cSpell.enabledLanguageIds": [
+        "csharp",
+        "git-commit", 
+        "markdown",
+        "plaintext",
+        "powershell",
+        "text",
+        "yaml",
+        "yml"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Enforce minimum TLS version for App Service. [#99](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/99)
 - Updated App Service site rules to include slots. [#100](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/100)
   - `Azure.AppService.ARRAffinity` and `Azure.AppService.UseHTTPS` now run against slots.
+- Added rule to detect deny all inbound NSG rule. [#94](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/94)
+- Added unused resource rules.
+  - Network security groups that are not associated. [#93](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/93)
+  - Unattached network interfaces. [#92](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/92)
+- Added NSG rule to check for lateral traversal security rules. [#103](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/103)
 
 ## v0.3.0-B190710 (pre-release)
 

--- a/docs/rules/en-US/Azure.VirtualNetwork.LateralTraversal.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.LateralTraversal.md
@@ -1,0 +1,23 @@
+---
+severity: Important
+category: Security configuration
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.LateralTraversal.md
+---
+
+# Limit lateral traversal
+
+## SYNOPSIS
+
+Deny outbound management connections from non-management hosts.
+
+## DESCRIPTION
+
+Network Security Groups (NSGs) allow virtual machines to be segmented from each other by enforcing access rules for all traffic in/ out of a virtual machine.
+
+This micro-segmentation approach provides a control to reduce lateral movement between hosts within Azure, a virtual network or an individual subnet.
+
+Typically, a subset of trusted hosts such as privileged access workstations, bastion hosts or jump boxes will be used for management. Management protocols originating from application workload hosts should be blocked.
+
+## RECOMMENDATION
+
+Consider configuring NSGs rules to block outbound management traffic from non-management hosts.

--- a/docs/rules/en-US/Azure.VirtualNetwork.NICAttached.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.NICAttached.md
@@ -1,0 +1,19 @@
+---
+severity: Awareness
+category: Operations management
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.NICAttached.md
+---
+
+# Attach NIC or clean up
+
+## SYNOPSIS
+
+Network interfaces (NICs) should be attached.
+
+## DESCRIPTION
+
+NICs are deployed as resources separate from virtual machines. NICs that are not attached to a virtual machine perform no purpose.
+
+## RECOMMENDATION
+
+Consider cleaning up NICs that are not required to reduce management complexity. Also consider using Resource Groups to help manage the lifecycle of related resources together.

--- a/docs/rules/en-US/Azure.VirtualNetwork.NSGAssociated.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.NSGAssociated.md
@@ -1,0 +1,19 @@
+---
+severity: Awareness
+category: Operations management
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.NSGAssociated.md
+---
+
+# Associate NSGs or clean up
+
+## SYNOPSIS
+
+Network Security Groups (NSGs) should be associated.
+
+## DESCRIPTION
+
+NSGs basic stateful firewalls that are deployed as separate resources and can be associated to network interfaces or subnets. NSGs that are not associated with a network interface or subnet perform no purpose.
+
+## RECOMMENDATION
+
+Consider cleaning up NSGs that are not required to reduce management complexity. Also consider using Resource Groups to help manage the lifecycle of related resources together.

--- a/docs/rules/en-US/Azure.VirtualNetwork.NSGDenyAllInbound.md
+++ b/docs/rules/en-US/Azure.VirtualNetwork.NSGDenyAllInbound.md
@@ -1,0 +1,25 @@
+---
+severity: Important
+category: Reliability
+online version: https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/docs/rules/en-US/Azure.VirtualNetwork.NSGDenyAllInbound.md
+---
+
+# Avoid denying all inbound traffic
+
+## SYNOPSIS
+
+Avoid denying all inbound traffic.
+
+## DESCRIPTION
+
+Network Security Groups can be configured to block all network traffic inbound to a virtual machine.
+
+Blocking all inbound traffic into a virtual machine will fail load balancer health probes and other required traffic.
+
+Inbound network traffic can be whitelisted by including allow rules above deny all inbound rule by specifying a lower priority number. Rules with a lower priority number will be process first.
+
+## RECOMMENDATION
+
+Deny all inbound rules should not use priority 100. The lowest configurable priority is 100, meaning that whitelisted network traffic rules can not be placed before the deny all.
+
+Consider whitelisting inbound network traffic as required.

--- a/docs/rules/en-US/Azure.md
+++ b/docs/rules/en-US/Azure.md
@@ -11,6 +11,7 @@ RuleName | Description | Category
 [Azure.AppService.MinPlan](Azure.AppService.MinPlan.md) | Use at least a Standard App Service Plan. | Performance
 [Azure.AppService.ARRAffinity](Azure.AppService.ARRAffinity.md) | Disable client affinity for stateless services. | Performance
 [Azure.AppService.UseHTTPS](Azure.AppService.UseHTTPS.md) | Use HTTPS only. Disable HTTP when not required. | Security configuration
+[Azure.AppService.MinTLS](Azure.AppService.MinTLS.md) | App Service should reject TLS versions older then 1.2. | Security configuration
 [Azure.DataFactory.Version](Azure.DataFactory.Version.md) | Consider migrating to DataFactory v2. | Operations management
 [Azure.MySQL.UseSSL](Azure.MySQL.UseSSL.md) | Enforce encrypted MySQL connections. | Security configuration
 [Azure.MySQL.FirewallRuleCount](Azure.MySQL.FirewallRuleCount.md) | Determine if there is an excessive number of firewall rules. | Operations management
@@ -52,6 +53,9 @@ RuleName | Description | Category
 [Azure.VirtualNetwork.SingleDNS](Azure.VirtualNetwork.SingleDNS.md) | VNETs should have at least two DNS servers assigned. | Reliability
 [Azure.VirtualNetwork.LocalDNS](Azure.VirtualNetwork.LocalDNS.md) | Virtual networks (VNETs) should use Azure local DNS servers. | Reliability
 [Azure.VirtualNetwork.NSGAnyInboundSource](Azure.VirtualNetwork.NSGAnyInboundSource.md) | Network security groups should avoid any inbound rules. | Security configuration
+[Azure.VirtualNetwork.NSGDenyAllInbound](Azure.VirtualNetwork.NSGDenyAllInbound.md) | Avoid denying all inbound traffic. | Reliability
+[Azure.VirtualNetwork.LateralTraversal](Azure.VirtualNetwork.LateralTraversal.md) | Deny outbound management connections from non-management hosts. | Security configuration
+[Azure.VirtualNetwork.NSGAssociated](Azure.VirtualNetwork.NSGAssociated.md) | Network Security Groups (NSGs) should be associated. | Operations management
 [Azure.VirtualNetwork.AppGwMinInstance](Azure.VirtualNetwork.AppGwMinInstance.md) | Application Gateways should use a minimum of two instances. | Reliability
 [Azure.VirtualNetwork.AppGwMinSku](Azure.VirtualNetwork.AppGwMinSku.md) | Application Gateway should use a minimum instance size of Medium. | Performance
 [Azure.VirtualNetwork.AppGwUseWAF](Azure.VirtualNetwork.AppGwUseWAF.md) | Internet accessible Application Gateways should use WAF. | Security configuration
@@ -60,3 +64,4 @@ RuleName | Description | Category
 [Azure.VirtualNetwork.AppGwWAFEnabled](Azure.VirtualNetwork.AppGwWAFEnabled.md) | Application Gateway Web Application Firewall (WAF) must be enabled to protect backend resources. | Security configuration
 [Azure.VirtualNetwork.AppGwOWASP](Azure.VirtualNetwork.AppGwOWASP.md) | Application Gateway Web Application Firewall (WAF) should use OWASP 3.x rules. | Security configuration
 [Azure.VirtualNetwork.AppGwWAFRules](Azure.VirtualNetwork.AppGwWAFRules.md) | Application Gateway Web Application Firewall (WAF) should have all rules enabled. | Security configuration
+[Azure.VirtualNetwork.NICAttached](Azure.VirtualNetwork.NICAttached.md) | Network interfaces (NICs) should be attached. | Operations management

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -32,6 +32,14 @@ function global:IsExport {
     }
 }
 
+# Get a sorted list of NSG rules
+function global:GetOrderedNSGRules {
+    param ()
+    process {
+        $TargetObject.properties.securityRules | Sort-Object @{ Expression = { $_.Properties.priority }; Descending = $False }
+    }
+}
+
 function global:SupportsAcceleratedNetworking {
     process {
         if ($TargetObject.ResourceType -ne 'Microsoft.Compute/virtualMachines' -or !(IsExport)) {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -86,6 +86,54 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'nsg-A', 'nsg-C';
+        }
+
+        It 'Azure.VirtualNetwork.NSGDenyAllInbound' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NSGDenyAllInbound' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'nsg-A', 'nsg-B';
+        }
+
+        It 'Azure.VirtualNetwork.LateralTraversal' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.LateralTraversal' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -BeIn 'nsg-A', 'nsg-B';
+        }
+
+        It 'Azure.VirtualNetwork.NSGAssociated' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NSGAssociated' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'nsg-B', 'nsg-C';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'nsg-A';
         }
@@ -216,6 +264,22 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
             $ruleResult.TargetName | Should -Be 'appgw-A';
+        }
+
+        It 'Azure.VirtualNetwork.NICAttached' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NICAttached' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nic-B';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nic-A';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -936,6 +936,208 @@
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     },
     {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C",
+        "Location": "region",
+        "ResourceName": "nsg-C",
+        "Name": "nsg-C",
+        "Properties": {
+            "securityRules": [
+                {
+                    "name": "allow-dc-to-dc-inbound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/securityRules/allow-dc-to-dc-inbound",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "properties": {
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "destinationAddressPrefix": "VirtualNetwork",
+                        "access": "Allow",
+                        "priority": 300,
+                        "direction": "Inbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [
+                            "10.1.0.32/28",
+                            "10.2.0.32/28",
+                            "10.3.0.32/28"
+                        ],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "deny-all-inbound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/securityRules/allow-rdp-inbound",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "properties": {
+                        "protocol": "Tcp",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "destinationAddressPrefix": "VirtualNetwork",
+                        "access": "Deny",
+                        "priority": 200,
+                        "direction": "Inbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefix": "*",
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "allow-dc-to-dc-outbound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/securityRules/allow-dc-to-dc-outbound",
+                    "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+                    "properties": {
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "VirtualNetwork",
+                        "access": "Allow",
+                        "priority": 300,
+                        "direction": "Outbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": [
+                            "10.1.0.32/28",
+                            "10.2.0.32/28",
+                            "10.3.0.32/28"
+                        ]
+                    }
+                }
+            ],
+            "defaultSecurityRules": [
+                {
+                    "name": "AllowVnetInBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/AllowVnetInBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Allow inbound traffic from all VMs in VNET",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "VirtualNetwork",
+                        "destinationAddressPrefix": "VirtualNetwork",
+                        "access": "Allow",
+                        "priority": 65000,
+                        "direction": "Inbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "AllowAzureLoadBalancerInBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/AllowAzureLoadBalancerInBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Allow inbound traffic from azure load balancer",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "AzureLoadBalancer",
+                        "destinationAddressPrefix": "*",
+                        "access": "Allow",
+                        "priority": 65001,
+                        "direction": "Inbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "DenyAllInBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/DenyAllInBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Deny all inbound traffic",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "*",
+                        "destinationAddressPrefix": "*",
+                        "access": "Deny",
+                        "priority": 65500,
+                        "direction": "Inbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "AllowVnetOutBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/AllowVnetOutBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "VirtualNetwork",
+                        "destinationAddressPrefix": "VirtualNetwork",
+                        "access": "Allow",
+                        "priority": 65000,
+                        "direction": "Outbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "AllowInternetOutBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/AllowInternetOutBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Allow outbound traffic from all VMs to Internet",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "*",
+                        "destinationAddressPrefix": "Internet",
+                        "access": "Allow",
+                        "priority": 65001,
+                        "direction": "Outbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                },
+                {
+                    "name": "DenyAllOutBound",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkSecurityGroups/nsg-C/defaultSecurityRules/DenyAllOutBound",
+                    "type": "Microsoft.Network/networkSecurityGroups/defaultSecurityRules",
+                    "properties": {
+                        "description": "Deny all outbound traffic",
+                        "protocol": "*",
+                        "sourcePortRange": "*",
+                        "destinationPortRange": "*",
+                        "sourceAddressPrefix": "*",
+                        "destinationAddressPrefix": "*",
+                        "access": "Deny",
+                        "priority": 65500,
+                        "direction": "Outbound",
+                        "sourcePortRanges": [],
+                        "destinationPortRanges": [],
+                        "sourceAddressPrefixes": [],
+                        "destinationAddressPrefixes": []
+                    }
+                }
+            ],
+            "networkInterfaces": []
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkSecurityGroups",
+        "ResourceType": "Microsoft.Network/networkSecurityGroups",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
         "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-A",
         "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/applicationGateways/appgw-A",
         "Location": "region",
@@ -1479,6 +1681,107 @@
         "ResourceGroupName": "test-rg",
         "Type": "Microsoft.Network/applicationGateways",
         "ResourceType": "Microsoft.Network/applicationGateways",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A",
+        "Location": "region",
+        "ResourceName": "nic-A",
+        "Name": "nic-A",
+        "Properties": {
+            "ipConfigurations": [
+                {
+                    "name": "ipconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-A/ipConfigurations/ipconfig1",
+                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "privateIPAddress": "10.0.0.4",
+                        "privateIPAllocationMethod": "Static",
+                        "publicIPAddress": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-A-pip"
+                        },
+                        "subnet": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                        },
+                        "primary": true,
+                        "privateIPAddressVersion": "IPv4"
+                    }
+                }
+            ],
+            "dnsSettings": {
+                "dnsServers": [
+                    "8.8.8.8"
+                ],
+                "appliedDnsServers": [
+                    "8.8.8.8"
+                ],
+                "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+            },
+            "macAddress": "00-00-00-00-00-00",
+            "enableAcceleratedNetworking": false,
+            "enableIPForwarding": false,
+            "primary": true,
+            "virtualMachine": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/vm-A"
+            },
+            "hostedWorkloads": [],
+            "tapConfigurations": []
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
+        "Tags": null,
+        "SubscriptionId": "00000000-0000-0000-0000-000000000000"
+    },
+    {
+        "ResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
+        "Id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B",
+        "Location": "region",
+        "ResourceName": "nic-B",
+        "Name": "nic-B",
+        "Properties": {
+            "ipConfigurations": [
+                {
+                    "name": "ipconfig1",
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/networkInterfaces/nic-B/ipConfigurations/ipconfig1",
+                    "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                    "properties": {
+                        "provisioningState": "Succeeded",
+                        "privateIPAddress": "10.0.0.5",
+                        "privateIPAllocationMethod": "Static",
+                        "publicIPAddress": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/publicIPAddresses/nic-B-pip"
+                        },
+                        "subnet": {
+                            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A"
+                        },
+                        "primary": true,
+                        "privateIPAddressVersion": "IPv4"
+                    }
+                }
+            ],
+            "dnsSettings": {
+                "dnsServers": [
+                    "8.8.8.8"
+                ],
+                "appliedDnsServers": [
+                    "8.8.8.8"
+                ],
+                "internalDomainNameSuffix": "example.nn.internal.cloudapp.net"
+            },
+            "macAddress": "00-00-00-00-00-00",
+            "enableAcceleratedNetworking": false,
+            "enableIPForwarding": false,
+            "primary": true,
+            "hostedWorkloads": [],
+            "tapConfigurations": []
+        },
+        "ResourceGroupName": "test-rg",
+        "Type": "Microsoft.Network/networkInterfaces",
+        "ResourceType": "Microsoft.Network/networkInterfaces",
         "Tags": null,
         "SubscriptionId": "00000000-0000-0000-0000-000000000000"
     }


### PR DESCRIPTION
## PR Summary

- Added rule to detect deny all inbound NSG rule. #94
- Added unused resource rules.
  - Network security groups that are not associated. #93
  - Unattached network interfaces. #92
- Added NSG rule to check for lateral traversal security rules. #103)

Fixes #94 
Fixes #93 
Fixes #92 
Fixes #103 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
