### PR TITLE
Pre-release v0.5.0-B1910004

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.5.0-B1910004 (pre-release)
+
 - Added rule to verify Windows automatic updates are enabled. [#132](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/132)
 - Added rule to verify VM agent is automatically provisioned. [#131](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/131)
 - Updated `Azure.AKS.Version` to 1.14.6. [#130](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/130)

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -152,15 +152,15 @@ task PSScriptAnalyzer NuGet, {
 # Synopsis: Install PSRule
 task PSRule NuGet, {
     if ($Null -eq (Get-InstalledModule -Name PSRule -MinimumVersion 0.10.0 -ErrorAction Ignore)) {
-        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 0.10.0-B1910011 -AllowPrerelease -Scope CurrentUser -Force;
+        Install-Module -Name PSRule -Repository PSGallery -MinimumVersion 0.10.0 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSRule -Verbose:$False;
 }
 
 # Synopsis: Install PSDocs
 task PSDocs NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion 0.6.1 -ErrorAction Ignore)) {
-        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion 0.6.1 -AllowPrerelease -Scope CurrentUser -Force;
+    if ($Null -eq (Get-InstalledModule -Name PSDocs -MinimumVersion 0.6.3 -ErrorAction Ignore)) {
+        Install-Module -Name PSDocs -Repository PSGallery -MinimumVersion 0.6.3 -Scope CurrentUser -Force;
     }
     Import-Module -Name PSDocs -Verbose:$False;
 }


### PR DESCRIPTION
## PR Summary

- Added rule to verify Windows automatic updates are enabled. #132
- Added rule to verify VM agent is automatically provisioned. #131
- Updated `Azure.AKS.Version` to 1.14.6. #130
- **Breaking change**: Renamed `Azure.VirtualMachine.*` rules to `Azure.VM.*` #119

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
