### PR TITLE
Pre-release v0.6.0-B1911011

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0-B1911011 (pre-release)
+
 - Updated `Azure.AKS.Version` to 1.14.8. [#140](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/140)
 - Updated rules to use type pre-conditions. [#144](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/144)
 - **Experimental**: Added support for exporting rule data from templates. [#145](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/145)


### PR DESCRIPTION
## PR Summary

- Updated `Azure.AKS.Version` to 1.14.8. #140
- Updated rules to use type pre-conditions. #144
- **Experimental**: Added support for exporting rule data from templates. #145
  - Added `Export-AzTemplateRuleData` cmdlet to export templates. See cmdlet help for limitations.
  - Template and parameters are merged, resolving functions, copy loops and conditions.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
