### PR TITLE
Fix VNET rule processing #149 #150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Fix processing of `Azure.VirtualNetwork.NSGAssociated` for templates. [#150](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/150)
+- Fix processing of `Azure.VirtualNetwork.LateralTraversal` when `destinationPortRanges` is used. [#149](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/149)
+
 ## v0.6.0-B1911011 (pre-release)
 
 - Updated `Azure.AKS.Version` to 1.14.8. [#140](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/140)

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -30,7 +30,7 @@ function global:IsExport {
     [OutputType([System.Boolean])]
     param ()
     process {
-        return $Null -ne $TargetObject.PSObject.Properties.Match('SubscriptionId');
+        return $Null -ne $TargetObject.SubscriptionId;
     }
 }
 
@@ -53,9 +53,15 @@ function global:HasPeerNetwork {
 
 # Get a sorted list of NSG rules
 function global:GetOrderedNSGRules {
-    param ()
+    param (
+        [Parameter(Mandatory = $True)]
+        [ValidateSet('Inbound', 'Outbound')]
+        [String]$Direction
+    )
     process {
-        $TargetObject.properties.securityRules | Sort-Object @{ Expression = { $_.Properties.priority }; Descending = $False }
+        $TargetObject.properties.securityRules |
+            Where-Object { $_.properties.direction -eq $Direction } |
+            Sort-Object @{ Expression = { $_.Properties.priority }; Descending = $False }
     }
 }
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -320,4 +320,136 @@ Describe 'Azure.VirtualNetwork' -Tag 'Network' {
             $ruleResult.TargetName | Should -BeIn 'kubernetes', 'lb-A';
         }
     }
+
+    Context 'With Template' {
+        $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
+        $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
+        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.VirtualNetwork.json;
+        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+
+        It 'Azure.VirtualNetwork.UseNSGs' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.UseNSGs' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+        }
+
+        It 'Azure.VirtualNetwork.SingleDNS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.SingleDNS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+        }
+
+        It 'Azure.VirtualNetwork.LocalDNS' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.LocalDNS' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+        }
+
+        It 'Azure.VirtualNetwork.PeerState' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.PeerState' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' -and $_.TargetType -eq 'Microsoft.Network/virtualNetworks' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+        }
+
+        It 'Azure.VirtualNetwork.NSGAnyInboundSource' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NSGAnyInboundSource' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet1', 'nsg-subnet2';
+        }
+
+        It 'Azure.VirtualNetwork.NSGDenyAllInbound' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NSGDenyAllInbound' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet1';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet2';
+        }
+
+        It 'Azure.VirtualNetwork.LateralTraversal' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.LateralTraversal' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet2';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet1';
+        }
+
+        It 'Azure.VirtualNetwork.NSGAssociated' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.VirtualNetwork.NSGAssociated' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -BeNullOrEmpty;
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' -and $_.TargetType -eq 'Microsoft.Network/networkSecurityGroups' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetName | Should -Be 'nsg-subnet1', 'nsg-subnet2';
+        }
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -3,9 +3,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 # Setup error handling
 $ErrorActionPreference = 'Stop';

--- a/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.VirtualNetwork.json
@@ -814,14 +814,15 @@
                         "description": "Prevent outbound RDP.",
                         "protocol": "Tcp",
                         "sourcePortRange": "*",
-                        "destinationPortRange": "3389",
                         "sourceAddressPrefix": "VirtualNetwork",
                         "destinationAddressPrefix": "*",
                         "access": "Deny",
                         "priority": 200,
                         "direction": "Outbound",
                         "sourcePortRanges": [],
-                        "destinationPortRanges": [],
+                        "destinationPortRanges": [
+                            "3389"
+                        ],
                         "sourceAddressPrefixes": [],
                         "destinationAddressPrefixes": []
                     }

--- a/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Rule.Common.Tests.ps1
@@ -30,7 +30,7 @@ Describe 'Rule quality' {
                 $rule.Info.Annotations.category | Should -Not -BeNullOrEmpty;
 
                 if ($rule.RuleName.Length -gt 35) {
-                    Write-Warning -Message "Rule name $($rule.RuleName) if longer than 35 characters.";
+                    Write-Warning -Message "Rule name $($rule.RuleName) is longer than 35 characters.";
                 }
             }
         }


### PR DESCRIPTION
## PR Summary

- Fix processing of `Azure.VirtualNetwork.NSGAssociated` for templates. #150
- Fix processing of `Azure.VirtualNetwork.LateralTraversal` when `destinationPortRanges` is used. #149

Fixes #149 
Fixes #150 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
