### PR TITLE
Improved template support #145

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix processing of `Azure.VirtualNetwork.NSGAssociated` for templates. [#150](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/150)
 - Fix processing of `Azure.VirtualNetwork.LateralTraversal` when `destinationPortRanges` is used. [#149](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/149)
+- Improved template support of `Export-AzTemplateRuleData` cmdlet. [#145](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/145)
+  - Added support for nested templates.
+  - Added support for `array`, `createArray`, `coalesce`, `intersection`, `dataUri` and `dataUriToString` functions.
 
 ## v0.6.0-B1911011 (pre-release)
 

--- a/docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md
+++ b/docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md
@@ -34,14 +34,13 @@ This function does not check template files for strict compliance with Azure sch
 
 Currently the following limitations also apply:
 
-- Deployments are not expanded. Deployment is returned instead of resources in deployment.
+- Nested templates are expanded, external templates are not.
+  - Deployment resources that link to an external template are returned as a resource.
 - The following functions are not supported:
-  - Array: `array`, `coalesce`, `createArray`, `intersection`
   - Deployment: `deployment`
   - Resource: `providers`
-  - String: `dataUri`, `dataUriToString`
 - References to Key Vault secrets are not expanded. A placeholder value is used instead.
-- Multi-line strings are not supported.
+- Multi-line strings and user-defined functions are not supported.
 
 ## EXAMPLES
 

--- a/src/PSRule.Rules.Azure/Data/Template/Exceptions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Exceptions.cs
@@ -1,0 +1,77 @@
+﻿using PSRule.Rules.Azure.Pipeline;
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+
+namespace PSRule.Rules.Azure.Data.Template
+{
+    /// <summary>
+    /// A template exception.
+    /// </summary>
+    public abstract class TemplateException : PipelineException
+    {
+        protected TemplateException()
+        {
+        }
+
+        protected TemplateException(string message) : base(message)
+        {
+        }
+
+        protected TemplateException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected TemplateException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+
+    public enum FunctionErrorType
+    {
+        MismatchingResourceSegments
+    }
+
+    [Serializable]
+    public sealed class TemplateFunctionException : TemplateException
+    {
+        public TemplateFunctionException()
+        {
+        }
+
+        public TemplateFunctionException(string message)
+            : base(message) { }
+
+        public TemplateFunctionException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        internal TemplateFunctionException(string functionName, FunctionErrorType errorType, string message)
+            : base(message)
+        {
+            FunctionName = functionName;
+            ErrorType = errorType;
+        }
+
+        internal TemplateFunctionException(string functionName, FunctionErrorType errorType, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            FunctionName = functionName;
+            ErrorType = errorType;
+        }
+
+        private TemplateFunctionException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+
+        public string FunctionName { get; }
+
+        public FunctionErrorType ErrorType { get; }
+    }
+}

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -25,7 +25,7 @@ namespace PSRule.Rules.Azure.Data.Template
             return Lexer(Parse(s));
         }
 
-        private TokenStream Parse(string s)
+        private static TokenStream Parse(string s)
         {
             return ExpressionParser.Parse(s);
         }

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionStream.cs
@@ -17,8 +17,6 @@ namespace PSRule.Rules.Azure.Data.Template
         /// The current character position in the expression string. Call Next() to change the position.
         /// </summary>
         private int _Position;
-        private int _Line;
-        private int _Column;
         private char _Current;
         private char _Previous;
         private int _EscapeLength;
@@ -47,17 +45,12 @@ namespace PSRule.Rules.Azure.Data.Template
             _Source = expression;
             _Length = _Source.Length;
             _Position = 0;
-            _Line = 0;
-            _Column = 0;
             _EscapeLength = 0;
 
             if (_Length < 0 || _Length > MaxLength)
                 throw new ArgumentOutOfRangeException(nameof(expression));
 
             UpdateCurrent();
-
-            if (_Source.Length > 0)
-                _Line = 1;
         }
 
         #region Properties
@@ -67,32 +60,12 @@ namespace PSRule.Rules.Azure.Data.Template
             get { return _Position >= _Length; }
         }
 
-        public bool IsStartOfLine
-        {
-            get { return _Column == 0; }
-        }
-
         /// <summary>
         /// The character at the current position in the stream.
         /// </summary>
         public char Current
         {
             get { return _Current; }
-        }
-
-        public char Previous
-        {
-            get { return _Previous; }
-        }
-
-        public int Line
-        {
-            get { return _Line; }
-        }
-
-        public int Column
-        {
-            get { return _Column; }
         }
 
 #if DEBUG
@@ -110,11 +83,6 @@ namespace PSRule.Rules.Azure.Data.Template
         public int Position
         {
             get { return _Position; }
-        }
-
-        private int Remaining
-        {
-            get { return _Length - Position; }
         }
 
         public bool IsEscaped

--- a/src/PSRule.Rules.Azure/Data/Template/Models.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Models.cs
@@ -1,10 +1,29 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
 using System.Collections;
 using System.Collections.Generic;
 
 namespace PSRule.Rules.Azure.Data.Template
 {
+    [JsonConverter(typeof(StringEnumConverter))]
+    internal enum ParameterType
+    {
+        Array,
+
+        Bool,
+
+        Int,
+
+        Object,
+
+        String,
+
+        SecureString,
+
+        SecureObject
+    }
+
     public sealed class Subscription
     {
         private const string DEFAULT_ID = "/subscriptions/{{Subscription.SubscriptionId}}";

--- a/src/PSRule.Rules.Azure/Pipeline/Exceptions.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/Exceptions.cs
@@ -76,7 +76,9 @@ namespace PSRule.Rules.Azure.Pipeline
         [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            if (info == null) throw new ArgumentNullException("info");
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
             base.GetObjectData(info, context);
         }
     }

--- a/src/PSRule.Rules.Azure/Pipeline/TemplateSource.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplateSource.cs
@@ -2,8 +2,8 @@
 {
     public sealed class TemplateSource
     {
-        public readonly string TemplateFile;
-        public readonly string[] ParametersFile;
+        internal readonly string TemplateFile;
+        internal readonly string[] ParametersFile;
 
         public TemplateSource(string templateFile, string[] parametersFile)
         {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.Designer.cs
@@ -88,6 +88,15 @@ namespace PSRule.Rules.Azure.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The number of resource segments needs to match the provided resource type..
+        /// </summary>
+        internal static string MismatchingResourceSegments {
+            get {
+                return ResourceManager.GetString("MismatchingResourceSegments", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
         internal static string ReadJsonFailed {

--- a/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
+++ b/src/PSRule.Rules.Azure/Resources/PSRuleResources.resx
@@ -126,6 +126,9 @@
   <data name="FunctionNotFound" xml:space="preserve">
     <value>The function "{0}" was not found.</value>
   </data>
+  <data name="MismatchingResourceSegments" xml:space="preserve">
+    <value>The number of resource segments needs to match the provided resource type.</value>
+  </data>
   <data name="ReadJsonFailed" xml:space="preserve">
     <value>Read JSON failed.</value>
   </data>

--- a/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Cmdlet.Common.Tests.ps1
@@ -192,7 +192,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             $Null = Export-AzTemplateRuleData @exportParams;
             $result = Get-Content -Path $outputFile -Raw | ConvertFrom-Json;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Length | Should -Be 5;
+            $result.Length | Should -Be 8;
             $result[0].name | Should -Be 'vnet-001';
             $result[0].properties.subnets.Length | Should -Be 3;
             $result[0].properties.subnets[0].name | Should -Be 'GatewaySubnet';
@@ -223,7 +223,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             $Null = Export-AzTemplateRuleData @exportParams;
             $result = Get-Content -Path $outputFile -Raw | ConvertFrom-Json;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Length | Should -Be 5;
+            $result.Length | Should -Be 8;
             $result[0].properties.subnets.Length | Should -Be 3;
             $result[0].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
             $result[0].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/[\w\{\}\-\.]{1,}/providers/Microsoft\.Network/routeTables/route-subnet2$';
@@ -253,7 +253,7 @@ Describe 'Export-AzTemplateRuleData' -Tag 'Cmdlet','Export-AzTemplateRuleData' {
             $Null = Export-AzTemplateRuleData @exportParams;
             $result = Get-Content -Path $outputFile -Raw | ConvertFrom-Json;
             $result | Should -Not -BeNullOrEmpty;
-            $result.Length | Should -Be 5;
+            $result.Length | Should -Be 8;
             $result[0].properties.subnets.Length | Should -Be 3;
             $result[0].properties.subnets[2].properties.networkSecurityGroup.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/networkSecurityGroups/nsg-subnet2$';
             $result[0].properties.subnets[2].properties.routeTable.id | Should -Match '^/subscriptions/[\w\{\}\-\.]{1,}/resourceGroups/test-rg/providers/Microsoft\.Network/routeTables/route-subnet2$';

--- a/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/ExpressionParserTests.cs
@@ -1,30 +1,11 @@
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using PSRule.Rules.Azure.Data.Template;
-using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using PSRule.Rules.Azure.Data.Template;
 using Xunit;
 using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
 
 namespace PSRule.Rules.Azure
 {
-    public sealed class TemplateResolverTests
+    public sealed class ExpressionParserTests
     {
-        [Fact]
-        public void ResolveTemplateTest()
-        {
-            var resources = ProcessTemplate(GetSourcePath("Resources.Template.json"), GetSourcePath("Resources.Parameters.json"));
-            Assert.Equal(5, resources.Length);
-
-            var actual1 = resources[0];
-            Assert.Equal("vnet-001", actual1["name"]);
-            Assert.Equal("10.1.0.0/24", actual1["properties"]["addressSpace"]["addressPrefixes"][0]);
-            Assert.Equal(3, actual1["properties"]["subnets"].Value<JArray>().Count);
-            Assert.Equal("10.1.0.32/28", actual1["properties"]["subnets"][1]["properties"]["addressPrefix"]);
-
-        }
-
         [Fact]
         public void ParseExpression1()
         {
@@ -170,58 +151,6 @@ namespace PSRule.Rules.Azure
             var actual = fn(context);
 
             Assert.Equal("route-routeB", actual);
-        }
-
-        private static string GetSourcePath(string fileName)
-        {
-            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
-        }
-
-        private static JObject[] ProcessTemplate(string templateFile, string parametersFile)
-        {
-            var templateObject = ReadFile<DeploymentTemplate>(templateFile);
-            var parametersObject = ReadFile<DeploymentParameters>(parametersFile);
-            var visitor = new TestTemplateVisitor();
-            visitor.Visit(templateObject, parametersObject);
-            return visitor.TestResources.ToArray();
-        }
-
-        private static T ReadFile<T>(string path)
-        {
-            if (string.IsNullOrEmpty(path) || !File.Exists(path))
-                return default(T);
-
-            return JsonConvert.DeserializeObject<T>(File.ReadAllText(path));
-        }
-    }
-
-    internal sealed class TestSubnet
-    {
-        internal TestSubnet(string n, string[] r)
-        {
-            name = n;
-            route = r;
-        }
-
-        public string name { get; private set; }
-
-        public string[] route { get; private set; }
-    }
-
-    internal sealed class TestTemplateVisitor : TemplateVisitor
-    {
-        internal TestTemplateVisitor()
-            : base(null, null)
-        {
-            TestResources = new List<JObject>();
-        }
-
-        public List<JObject> TestResources { get; }
-
-        protected override void ResourceInstance(TemplateContext context, JObject resource)
-        {
-            base.ResourceInstance(context, resource);
-            TestResources.Add(resource);
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/FunctionTests.cs
@@ -22,6 +22,45 @@ namespace PSRule.Rules.Azure
 
         [Fact]
         [Trait(TRAIT, TRAIT_ARRAY)]
+        public void Array()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.Array(context, new object[] { 1 }) as JArray;
+            var actual2 = Functions.Array(context, new object[] { "efgh" }) as JArray;
+            var actual3 = Functions.Array(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }") }) as JArray;
+            Assert.Equal(1, actual1[0]);
+            Assert.Equal("efgh", actual2[0]);
+            Assert.Equal("b", actual3[0]["a"]);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Array(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Array(context, new object[] { }));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Array(context, new object[] { "abcd", "efgh" }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
+        public void Coalesce()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.Coalesce(context, new object[] { null, null, 1, 2, 3 });
+            var actual2 = Functions.Coalesce(context, new object[] { null, null, "a", "b", "c" });
+            var actual3 = Functions.Coalesce(context, new object[] { null, JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }") }) as JToken;
+            var actual4 = Functions.Coalesce(context, new object[] { null });
+            var actual5 = Functions.Coalesce(context, new object[] { null, null });
+            Assert.Equal(1, actual1);
+            Assert.Equal("a", actual2);
+            Assert.Equal("b", actual3["a"]);
+            Assert.Null(actual4);
+            Assert.Null(actual5);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Coalesce(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Coalesce(context, new object[] { }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
         public void Concat()
         {
             var context = GetContext();
@@ -50,6 +89,25 @@ namespace PSRule.Rules.Azure
             // Object
 
             // Array
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
+        public void CreateArray()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.CreateArray(context, new object[] { 1, 2, 3 }) as JArray;
+            var actual2 = Functions.CreateArray(context, new object[] { "efgh" }) as JArray;
+            var actual3 = Functions.CreateArray(context, new object[] { JObject.Parse("{ \"a\": \"b\", \"c\": \"d\" }"), JObject.Parse("{ \"e\": \"f\", \"g\": \"h\" }") }) as JArray;
+            Assert.Equal(3, actual1.Count);
+            Assert.Equal(1, actual1[0]);
+            Assert.Equal("efgh", actual2[0]);
+            Assert.Equal("b", actual3[0]["a"]);
+            Assert.Equal("h", actual3[1]["g"]);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.CreateArray(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.CreateArray(context, new object[] { }));
         }
 
         [Fact]
@@ -90,6 +148,32 @@ namespace PSRule.Rules.Azure
             // Array
             var actual2 = Functions.First(context, new object[] { new string[] { "one", "two", "three" } }) as string;
             Assert.Equal("one", actual2);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.First(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.First(context, new object[] { }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_ARRAY)]
+        public void Intersection()
+        {
+            var context = GetContext();
+
+            // String
+            var actual1 = Functions.Intersection(context, new object[] { new JArray("one", "two", "three"), new JArray("two", "three") }) as JArray;
+            Assert.Equal(2, actual1.Count);
+            Assert.Equal("two", actual1[0]);
+            Assert.Equal("three", actual1[1]);
+
+            // Array
+            var actual2 = Functions.Intersection(context, new object[] { JObject.Parse("{ \"one\": \"a\", \"two\": \"b\", \"three\": \"c\" }"), JObject.Parse("{ \"one\": \"a\", \"two\": \"z\", \"three\": \"c\" }") }) as JObject;
+            Assert.Equal(2, actual2.Count);
+            Assert.Equal("a", actual2["one"]);
+            Assert.Equal("c", actual2["three"]);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Intersection(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Intersection(context, new object[] { }));
+            Assert.Throws<ArgumentException>(() => Functions.Intersection(context, new object[] { "one", "two", "three" }));
         }
 
         [Fact]
@@ -100,6 +184,9 @@ namespace PSRule.Rules.Azure
 
             var actual1 = Functions.Json(context, new object[] { "{ \"a\": \"b\" }" }) as JObject;
             Assert.Equal("b", actual1["a"]);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Json(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Json(context, new object[] { }));
         }
 
         [Fact]
@@ -312,7 +399,7 @@ namespace PSRule.Rules.Azure
 
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.ExtensionResourceId(context, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.ExtensionResourceId(context, new object[] { "Extension.Test/type", "a" }));
-            Assert.Throws<ArgumentException>(() => Functions.ExtensionResourceId(context, new object[] { parentId, "Extension.Test/type", "a", "b" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.ExtensionResourceId(context, new object[] { parentId, "Extension.Test/type", "a", "b" }));
             Assert.Throws<ArgumentException>(() => Functions.ExtensionResourceId(context, new object[] { parentId, "Extension.Test/type", 1 }));
         }
 
@@ -373,7 +460,7 @@ namespace PSRule.Rules.Azure
 
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.ResourceId(context, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.ResourceId(context, new object[] { "Unit.Test/type" }));
-            Assert.Throws<ArgumentException>(() => Functions.ResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.ResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
             Assert.Throws<ArgumentException>(() => Functions.ResourceId(context, new object[] { "Unit.Test/type", 1 }));
         }
 
@@ -404,7 +491,7 @@ namespace PSRule.Rules.Azure
 
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.SubscriptionResourceId(context, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.SubscriptionResourceId(context, new object[] { "Unit.Test/type" }));
-            Assert.Throws<ArgumentException>(() => Functions.SubscriptionResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.SubscriptionResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
             Assert.Throws<ArgumentException>(() => Functions.SubscriptionResourceId(context, new object[] { "Unit.Test/type", 1 }));
         }
 
@@ -423,8 +510,8 @@ namespace PSRule.Rules.Azure
 
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.TenantResourceId(context, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.TenantResourceId(context, new object[] { "Unit.Test/type" }));
-            Assert.Throws<ArgumentException>(() => Functions.TenantResourceId(context, new object[] { "00000000-0000-0000-0000-000000000000", "Unit.Test/type" }));
-            Assert.Throws<ArgumentException>(() => Functions.TenantResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.TenantResourceId(context, new object[] { "00000000-0000-0000-0000-000000000000", "Unit.Test/type" }));
+            Assert.Throws<TemplateFunctionException>(() => Functions.TenantResourceId(context, new object[] { "Unit.Test/type", "a", "b" }));
             Assert.Throws<ArgumentException>(() => Functions.TenantResourceId(context, new object[] { "Unit.Test/type", 1 }));
         }
 
@@ -836,6 +923,39 @@ namespace PSRule.Rules.Azure
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Base64ToString(context, null));
             Assert.Throws<ArgumentOutOfRangeException>(() => Functions.Base64ToString(context, new object[] { }));
             Assert.Throws<ArgumentException>(() => Functions.Base64ToString(context, new object[] { 1 }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_STRING)]
+        public void DataUri()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.DataUri(context, new object[] { "Hello" }) as string;
+            Assert.Equal("data:text/plain;charset=utf8;base64,SGVsbG8=", actual1);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.DataUri(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.DataUri(context, new object[] { }));
+            Assert.Throws<ArgumentException>(() => Functions.DataUri(context, new object[] { 1 }));
+        }
+
+        [Fact]
+        [Trait(TRAIT, TRAIT_STRING)]
+        public void DataUriToString()
+        {
+            var context = GetContext();
+
+            var actual1 = Functions.DataUriToString(context, new object[] { "data:;base64,SGVsbG8sIFdvcmxkIQ==" }) as string;
+            var actual2 = Functions.DataUriToString(context, new object[] { "data:,SGVsbG8sIFdvcmxkIQ==" }) as string;
+            var actual3 = Functions.DataUriToString(context, new object[] { "data:text/plain;charset=utf8;base64,SGVsbG8=" }) as string;
+            Assert.Equal("Hello, World!", actual1);
+            Assert.Equal("SGVsbG8sIFdvcmxkIQ==", actual2);
+            Assert.Equal("Hello", actual3);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.DataUriToString(context, null));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Functions.DataUriToString(context, new object[] { }));
+            Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, new object[] { 1 }));
+            Assert.Throws<ArgumentException>(() => Functions.DataUriToString(context, new object[] { "SGVsbG8sIFdvcmxkIQ==" }));
         }
 
         [Fact]

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Parameters.json
@@ -55,6 +55,15 @@
                     "securityRules": []
                 }
             ]
+        },
+        "aciSubnet": {
+            "value": "subnet2"
+        },
+        "clusterSubnet": {
+            "value": "subnet1"
+        },
+        "clusterObjectId": {
+            "value": "00000000-0000-0000-0000-000000000000"
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -24,6 +24,13 @@
             "metadata": {
                 "description": ""
             }
+        },
+        "delegate": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": ""
+            }
         }
     },
     "variables": {
@@ -55,7 +62,11 @@
                 }
             ]
         },
-        "allSubnets": "[union(variables('gatewaySubnet'), variables('definedSubnets').subnets)]"
+        "allSubnets": "[union(variables('gatewaySubnet'), variables('definedSubnets').subnets)]",
+        "networkOperatorRoleId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+        "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]",
+        "clusterSubnetId": "[concat(variables('vnetId'), '/subnets/',parameters('clusterSubnet'))]",
+        "aciSubnetId": "[concat(variables('vnetId'), '/subnets/',parameters('aciSubnet'))]"
     },
     "resources": [
         {
@@ -73,6 +84,69 @@
                     "addressPrefixes": "[parameters('addressPrefix')]"
                 },
                 "subnets": "[variables('allSubnets')]"
+            }
+        },
+        {
+            "condition": "[parameters('delegate')]",
+            "comments": "VNET delegation for AKS cluster",
+            "apiVersion": "2017-05-10",
+            "type": "Microsoft.Resources/deployments",
+            "name": "vnetDelegation",
+            "resourceGroup": "[resourceGroup().name]",
+            "subscriptionId": "[subscription().subscriptionId]",
+            "properties": {
+                "mode": "Incremental",
+                "parameters": {
+                },
+                "template": {
+                    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {
+                    },
+                    "resources": [
+                        {
+                            "apiVersion": "2019-04-01",
+                            "name": "[concat(parameters('vnetName'), '/', parameters('aciSubnet'))]",
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "properties": {
+                                "addressPrefix": "[reference(variables('aciSubnetId'), '2019-07-01').addressPrefix]",
+                                "serviceEndpoints": [
+                                ],
+                                "delegations": [
+                                    {
+                                        "name": "aciDelegation",
+                                        "properties": {
+                                            "serviceName": "Microsoft.ContainerInstance/containerGroups",
+                                            "actions": [
+                                                "Microsoft.Network/virtualNetworks/subnets/action"
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
+                            "apiVersion": "2017-05-01",
+                            "name": "[concat(parameters('vnetName'), '/', parameters('clusterSubnet'), '/Microsoft.Authorization/', guid(parameters('clusterSubnet')))]",
+                            "properties": {
+                                "roleDefinitionId": "[variables('networkOperatorRoleId')]",
+                                "principalId": "[parameters('clusterObjectId')]",
+                                "scope": "[variables('clusterSubnetId')]"
+                            }
+                        },
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
+                            "apiVersion": "2017-05-01",
+                            "name": "[concat(parameters('vnetName'), '/', parameters('aciSubnet'), '/Microsoft.Authorization/', guid(parameters('aciSubnet')))]",
+                            "properties": {
+                                "roleDefinitionId": "[variables('networkOperatorRoleId')]",
+                                "principalId": "[parameters('clusterObjectId')]",
+                                "scope": "[variables('aciSubnetId')]"
+                            }
+                        }
+                    ]
+                }
             }
         },
         {

--- a/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
+++ b/tests/PSRule.Rules.Azure.Tests/TemplateVisitorTests.cs
@@ -1,0 +1,86 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using PSRule.Rules.Azure.Data.Template;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+using static PSRule.Rules.Azure.Data.Template.TemplateVisitor;
+
+namespace PSRule.Rules.Azure
+{
+    public sealed class TemplateVisitorTests
+    {
+        [Fact]
+        public void ResolveTemplateTest()
+        {
+            var resources = ProcessTemplate(GetSourcePath("Resources.Template.json"), GetSourcePath("Resources.Parameters.json"));
+            Assert.Equal(8, resources.Length);
+
+            var actual1 = resources[0];
+            Assert.Equal("vnet-001", actual1["name"]);
+            Assert.Equal("10.1.0.0/24", actual1["properties"]["addressSpace"]["addressPrefixes"][0]);
+            Assert.Equal(3, actual1["properties"]["subnets"].Value<JArray>().Count);
+            Assert.Equal("10.1.0.32/28", actual1["properties"]["subnets"][1]["properties"]["addressPrefix"]);
+
+            var actual2 = resources[1];
+            Assert.Equal("vnet-001/subnet2", actual2["name"]);
+
+            var actual3 = resources[2];
+            Assert.Equal("vnet-001/subnet1/Microsoft.Authorization/924b5b06-fe70-9ab7-03f4-14671370765e", actual3["name"]);
+        }
+
+        private static string GetSourcePath(string fileName)
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        private static JObject[] ProcessTemplate(string templateFile, string parametersFile)
+        {
+            var templateObject = ReadFile<JObject>(templateFile);
+            var parametersObject = ReadFile<DeploymentParameters>(parametersFile);
+            var visitor = new TestTemplateVisitor();
+            var context = new TemplateContext();
+            context.Load(parametersObject);
+            visitor.Visit(context, templateObject);
+            return visitor.TestResources.ToArray();
+        }
+
+        private static T ReadFile<T>(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !File.Exists(path))
+                return default(T);
+
+            return JsonConvert.DeserializeObject<T>(File.ReadAllText(path));
+        }
+    }
+
+    internal sealed class TestSubnet
+    {
+        internal TestSubnet(string n, string[] r)
+        {
+            name = n;
+            route = r;
+        }
+
+        public string name { get; private set; }
+
+        public string[] route { get; private set; }
+    }
+
+    internal sealed class TestTemplateVisitor : TemplateVisitor
+    {
+        internal TestTemplateVisitor()
+        {
+            TestResources = new List<JObject>();
+        }
+
+        public List<JObject> TestResources { get; }
+
+        protected override void Emit(TemplateContext context, JObject resource)
+        {
+            base.Emit(context, resource);
+            TestResources.Add(resource);
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Improved template support of `Export-AzTemplateRuleData` cmdlet. #145
  - Added support for nested templates.
  - Added support for `array`, `createArray`, `coalesce`, `intersection`, `dataUri` and `dataUriToString` functions.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
