### PR TITLE
Fix processing for resource rules #155 #156

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Fixed processing of `Azure.Resource.UseTags` to exclude `*/providers/roleAssignments`. [#155](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/155)
+  - Provider role assignments do not support tags.
+- Fixed processing of `Azure.Resource.AllowedRegions`. [#156](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/156)
+  - Exclude `*/providers/roleAssignments`, `Microsoft.Authorization/*` and `Microsoft.Consumption/*`.
+
 ## v0.6.0-B1911020 (pre-release)
 
 - Fixed processing of `Azure.VirtualNetwork.NSGAssociated` for templates. [#150](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/150)

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -186,7 +186,8 @@ function global:SupportsTags {
             ($Rule.TargetType -like 'Microsoft.Resources/*') -or
             ($Rule.TargetType -like 'Microsoft.Security/*') -or
             ($Rule.TargetType -like 'microsoft.support/*') -or
-            ($Rule.TargetType -like 'Microsoft.WorkloadMonitor/*')
+            ($Rule.TargetType -like 'Microsoft.WorkloadMonitor/*') -or
+            ($Rule.TargetType -like '*/providers/roleAssignments')
         ) {
             return $False;
         }
@@ -205,6 +206,9 @@ function global:SupportsRegions {
             ($Rule.TargetType -eq 'Microsoft.Subscription') -or
             ($Rule.TargetType -eq 'Microsoft.AzureActiveDirectory/b2cDirectories') -or
             ($Rule.TargetType -eq 'Microsoft.Network/trafficManagerProfiles') -or
+            ($Rule.TargetType -like 'Microsoft.Authorization/*') -or
+            ($Rule.TargetType -like 'Microsoft.Consumption/*') -or
+            ($Rule.TargetType -like '*/providers/roleAssignments') -or
             ($TargetObject.Location -eq 'global')
         ) {
             return $False;

--- a/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.Resource.Tests.ps1
@@ -65,4 +65,57 @@ Describe 'Azure.Resource' {
             $ruleResult.TargetName | Should -Be 'registry-C', 'trafficManager-A';
         }
     }
+
+    Context 'With Template' {
+        $templatePath = Join-Path -Path $here -ChildPath 'Resources.Template.json';
+        $parameterPath = Join-Path -Path $here -ChildPath 'Resources.Parameters.json';
+        $outputFile = Join-Path -Path $rootPath -ChildPath out/tests/Resources.Resource.json;
+        Export-AzTemplateRuleData -TemplateFile $templatePath -ParameterFile $parameterPath -OutputPath $outputFile;
+        $options = New-PSRuleOption -BaselineConfiguration @{ 'azureAllowedRegions' = @('region-A') };
+        $result = Invoke-PSRule -Module PSRule.Rules.Azure -Option $options -InputPath $outputFile -Outcome All -WarningAction Ignore -ErrorAction Stop;
+
+        It 'Azure.Resource.UseTags' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Resource.UseTags' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -BeIn 'vnet-001/subnet2', 'route-subnet1', 'route-subnet2', 'nsg-subnet1', 'nsg-subnet2';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetType | Should -BeIn 'Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments';
+        }
+
+        It 'Azure.Resource.AllowedRegions' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.Resource.AllowedRegions' };
+
+            # Fail
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 5;
+            $ruleResult.TargetName | Should -Be 'vnet-001/subnet2', 'route-subnet1', 'route-subnet2', 'nsg-subnet1', 'nsg-subnet2';
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -Be 'vnet-001';
+
+            # None
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'None' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 2;
+            $ruleResult.TargetType | Should -BeIn 'Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments';
+        }
+    }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -74,7 +74,7 @@
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('vnetName')]",
             "apiVersion": "2019-04-01",
-            "location": "[resourceGroup().location]",
+            "location": "region-A",
             "dependsOn": [
                 "routeIndex",
                 "nsgIndex"
@@ -84,6 +84,9 @@
                     "addressPrefixes": "[parameters('addressPrefix')]"
                 },
                 "subnets": "[variables('allSubnets')]"
+            },
+            "tags": {
+                "role": "Networking"
             }
         },
         {


### PR DESCRIPTION
## PR Summary

- Fixed processing of `Azure.Resource.UseTags` to exclude `*/providers/roleAssignments`. #155
  - Provider role assignments do not support tags.
- Fixed processing of `Azure.Resource.AllowedRegions`. #156
  - Exclude `*/providers/roleAssignments`, `Microsoft.Authorization/*` and `Microsoft.Consumption/*`.

Fixes #155 
Fixes #156 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
