### PR TITLE
Pre-release v0.6.0-B1911027

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0-B1911027 (pre-release)
+
 - Fixed processing of `Azure.Resource.UseTags` to exclude `*/providers/roleAssignments`. [#155](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/155)
   - Provider role assignments do not support tags.
 - Fixed processing of `Azure.Resource.AllowedRegions`. [#156](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/156)


### PR DESCRIPTION
## PR Summary

- Fixed processing of `Azure.Resource.UseTags` to exclude `*/providers/roleAssignments`. #155
  - Provider role assignments do not support tags.
- Fixed processing of `Azure.Resource.AllowedRegions`. #156
  - Exclude `*/providers/roleAssignments`, `Microsoft.Authorization/*` and `Microsoft.Consumption/*`.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
