### PR TITLE
Fix template export #162 #163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Improved template support of `Export-AzTemplateRuleData` cmdlet. [#145](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/145)
   - Added support for `deployment` function.
   - Fixed property copy loop.
+- Fixed `Export-AzTemplateRuleData` does not return FileInfo objects. [#162](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/162)
+- Fixed Automatically name outputs from `Export-AzTemplateRuleData`. [#163](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/163)
 
 ## v0.6.0-B1911027 (pre-release)
 

--- a/docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md
+++ b/docs/commands/PSRule.Rules.Azure/en-US/Export-AzTemplateRuleData.md
@@ -44,7 +44,7 @@ Currently the following limitations also apply:
 ### Example 1
 
 ```powershell
-PS C:\> Export-AzTemplateRuleData -Name 'hub-network' -TemplateFile .\template.json -ParameterFile .\parameters.json;
+PS C:\> Export-AzTemplateRuleData -TemplateFile .\template.json -ParameterFile .\parameters.json;
 ```
 
 Export resource configuration data based on merging a template and parameter file together.
@@ -54,8 +54,9 @@ Export resource configuration data based on merging a template and parameter fil
 ### -Name
 
 The name of the deployment.
+If not specified `export-<xxxxxxxx>` will be used as the name of the deployment.
 
-This parameter is used by the `deployment()` function.
+This parameter is used by the `deployment()` function and is also used to name the output file.
 
 ```yaml
 Type: String
@@ -189,6 +190,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ### System.String[]
 
 ## OUTPUTS
+
+### System.IO.FileInfo
 
 ### System.Object
 

--- a/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/PipelineBuilder.cs
@@ -88,7 +88,7 @@ namespace PSRule.Rules.Azure.Pipeline
         /// <param name="defaultFile">The default file name to use when a directory is specified.</param>
         /// <param name="encoding">The file encoding to use.</param>
         /// <param name="o">The text to write.</param>
-        protected static void WriteToFile(string path, string defaultFile, ShouldProcess shouldProcess, Encoding encoding, object o)
+        protected static void WriteToFile(string path, string defaultFile, ShouldProcess shouldProcess, WriteOutput output, Encoding encoding, object o)
         {
             var rootedPath = PSRuleOption.GetRootedPath(path: path);
             if (!Path.HasExtension(rootedPath) || Directory.Exists(rootedPath))
@@ -102,6 +102,8 @@ namespace PSRule.Rules.Azure.Pipeline
             if (shouldProcess(target: rootedPath, action: PSRuleResources.ShouldWriteFile))
             {
                 File.WriteAllText(path: rootedPath, contents: o.ToString(), encoding: encoding);
+                var info = new FileInfo(rootedPath);
+                output(info, false);
             }
         }
     }

--- a/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
+++ b/src/PSRule.Rules.Azure/Pipeline/TemplatePipeline.cs
@@ -31,7 +31,6 @@ namespace PSRule.Rules.Azure.Pipeline
         private const string OUTPUTFILE_EXTENSION = ".json";
 
         private const string DEPLOYMENTNAME_PREFIX = "export-";
-        private const string DEPLOYMENTNAME_TIMEFORMAT = "yyyy-MM-dd-hh-mm";
 
         private const string RESOURCEGROUP_RESOURCEID = "ResourceId";
         private const string RESOURCEGROUP_RESOURCEGROUPNAME = "ResourceGroupName";
@@ -51,7 +50,7 @@ namespace PSRule.Rules.Azure.Pipeline
         internal TemplatePipelineBuilder()
             : base()
         {
-            _DeploymentName = string.Concat(DEPLOYMENTNAME_PREFIX, DateTime.Now.ToString(DEPLOYMENTNAME_TIMEFORMAT, new CultureInfo("en-US")));
+            _DeploymentName = string.Concat(DEPLOYMENTNAME_PREFIX, Guid.NewGuid().ToString().Substring(0, 8));
             _ResourceGroup = Data.Template.ResourceGroup.Default;
             _Subscription = Data.Template.Subscription.Default;
         }
@@ -102,7 +101,7 @@ namespace PSRule.Rules.Azure.Pipeline
         protected override PipelineWriter PrepareWriter()
         {
             var defaultFile = string.Concat(OUTPUTFILE_PREFIX, _DeploymentName, OUTPUTFILE_EXTENSION);
-            WriteOutput output = (o, enumerate) => WriteToFile(_OutputPath, defaultFile, ShouldProcess, Encoding.UTF8, o);
+            WriteOutput output = (o, enumerate) => WriteToFile(_OutputPath, defaultFile, ShouldProcess, Output, Encoding.UTF8, o);
             return _PassThru ? base.PrepareWriter() : new JsonPipelineWriter(output);
         }
 


### PR DESCRIPTION
## PR Summary

- Fixed `Export-AzTemplateRuleData` does not return FileInfo objects. #162
- Fixed Automatically name outputs from `Export-AzTemplateRuleData`. #163

Fixed #162 
Fixed #163 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
