### PR TITLE
Fix quickstart templates #165 #167 #168

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   - Fixed property copy loop.
 - Fixed `Export-AzTemplateRuleData` does not return FileInfo objects. [#162](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/162)
 - Fixed Automatically name outputs from `Export-AzTemplateRuleData`. [#163](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/163)
+- Fixed resource segmentation issue when ResourceType includes trailing slash. [#165](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/165)
+- Fixed expand resource template property as null fails. [#167](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/167)
+- Fixed Case-sensitivity of variables and parameters. [#168](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/168)
 
 ## v0.6.0-B1911027 (pre-release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Fixed Automatically name outputs from `Export-AzTemplateRuleData`. [#163](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/163)
 - Fixed resource segmentation issue when ResourceType includes trailing slash. [#165](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/165)
 - Fixed expand resource template property as null fails. [#167](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/167)
-- Fixed Case-sensitivity of variables and parameters. [#168](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/168)
+- Fixed case-sensitivity of variables, parameters and functions. [#168](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/168)
 
 ## v0.6.0-B1911027 (pre-release)
 

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -218,7 +218,7 @@ task BuildModule BuildDotNet, CopyModule
 
 task TestRules TestDotNet, PSRule, Pester, PSScriptAnalyzer, {
     # Run Pester tests
-    $pesterParams = @{ Path = $PWD; OutputFile = 'reports/pester-unit.xml'; OutputFormat = 'NUnitXml'; PesterOption = @{ IncludeVSCodeMarker = $True }; PassThru = $True; };
+    $pesterParams = @{ Path = (Join-Path -Path $PWD -ChildPath tests/PSRule.Rules.Azure.Tests); OutputFile = 'reports/pester-unit.xml'; OutputFormat = 'NUnitXml'; PesterOption = @{ IncludeVSCodeMarker = $True }; PassThru = $True; };
 
     if ($CodeCoverage) {
         $pesterParams.Add('CodeCoverage', (Join-Path -Path $PWD -ChildPath 'out/modules/**/*.psm1'));

--- a/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/ExpressionBuilder.cs
@@ -167,7 +167,7 @@ namespace PSRule.Rules.Azure.Data.Template
 
         public ExpressionFactory()
         {
-            _Descriptors = new Dictionary<string, IFunctionDescriptor>();
+            _Descriptors = new Dictionary<string, IFunctionDescriptor>(StringComparer.OrdinalIgnoreCase);
             foreach (var d in Functions.Builtin)
                 With(d);
         }

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -680,7 +680,7 @@ namespace PSRule.Rules.Azure.Data.Template
                         subscriptionId = segments[0];
                     }
                     resourceType = segments[i];
-                    var nameDepth = resourceType.Split('/').Length - 1;
+                    var nameDepth = resourceType.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Length - 1;
 
                     if ((segments.Length - 1 - i) != nameDepth)
                         throw new TemplateFunctionException(nameof(ResourceId), FunctionErrorType.MismatchingResourceSegments, PSRuleResources.MismatchingResourceSegments);

--- a/src/PSRule.Rules.Azure/Data/Template/Functions.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/Functions.cs
@@ -599,7 +599,7 @@ namespace PSRule.Rules.Azure.Data.Template
             if (!segments[1].Contains('/'))
                 throw new ArgumentException();
 
-            var resourceType = segments[1];
+            var resourceType = TrimResourceType(segments[1]);
             var nameDepth = resourceType.Split('/').Length - 1;
             if ((segments.Length - 2) != nameDepth)
                 throw new TemplateFunctionException(nameof(ExtensionResourceId), FunctionErrorType.MismatchingResourceSegments, PSRuleResources.MismatchingResourceSegments);
@@ -679,8 +679,8 @@ namespace PSRule.Rules.Azure.Data.Template
                         resourceGroup = segments[1];
                         subscriptionId = segments[0];
                     }
-                    resourceType = segments[i];
-                    var nameDepth = resourceType.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries).Length - 1;
+                    resourceType = TrimResourceType(segments[i]);
+                    var nameDepth = resourceType.Split('/').Length - 1;
 
                     if ((segments.Length - 1 - i) != nameDepth)
                         throw new TemplateFunctionException(nameof(ResourceId), FunctionErrorType.MismatchingResourceSegments, PSRuleResources.MismatchingResourceSegments);
@@ -736,7 +736,7 @@ namespace PSRule.Rules.Azure.Data.Template
                     if (i == 1)
                         subscriptionId = segments[0];
 
-                    resourceType = segments[i];
+                    resourceType = TrimResourceType(segments[i]);
                     var nameDepth = resourceType.Split('/').Length - 1;
 
                     if ((segments.Length - 1 - i) != nameDepth)
@@ -777,7 +777,7 @@ namespace PSRule.Rules.Azure.Data.Template
             {
                 if (segments[i].Contains('/'))
                 {
-                    resourceType = segments[i];
+                    resourceType = TrimResourceType(segments[i]);
                     var nameDepth = resourceType.Split('/').Length - 1;
 
                     if ((segments.Length - 1 - i) != nameDepth)
@@ -1542,6 +1542,11 @@ namespace PSRule.Rules.Azure.Data.Template
                 }
                 return algorithm.Hash;
             }
+        }
+
+        private static string TrimResourceType(string resourceType)
+        {
+            return resourceType[resourceType.Length - 1] == '/' ? resourceType = resourceType.Substring(0, resourceType.Length - 1) : resourceType;
         }
 
         #endregion Helper functions

--- a/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
+++ b/src/PSRule.Rules.Azure/Data/Template/TemplateVisitor.cs
@@ -30,8 +30,8 @@ namespace PSRule.Rules.Azure.Data.Template
             internal TemplateContext()
             {
                 Resources = new List<JObject>();
-                Parameters = new Dictionary<string, object>();
-                Variables = new Dictionary<string, object>();
+                Parameters = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+                Variables = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
                 CopyIndex = new CopyIndexStore();
                 ResourceGroup = new ResourceGroup();
                 Subscription = new Subscription();
@@ -455,7 +455,8 @@ namespace PSRule.Rules.Azure.Data.Template
             if (!TryExpressionString(value, out string svalue))
                 return value;
 
-            return JToken.FromObject(EvaluteExpression<object>(context, svalue));
+            var result = EvaluteExpression<object>(context, svalue);
+            return result == null ? null : JToken.FromObject(result);
         }
 
         private T ExpandProperty<T>(TemplateContext context, JObject value, string propertyName)

--- a/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.Template.json
@@ -64,7 +64,7 @@
                                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat('nsg-', parameters('subnets')[copyIndex('subnets')].name))]"
                             },
                             "routeTable": {
-                                "id": "[resourceId('Microsoft.Network/routeTables', concat('route-', parameters('subnets')[copyIndex('subnets')].name))]"
+                                "id": "[resourceId('Microsoft.Network/routeTables/', concat('route-', parameters('subnets')[copyIndex('subnets')].name))]"
                             }
                         }
                     }
@@ -81,7 +81,7 @@
         {
             "comments": "Hub virtual network",
             "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('vnetName')]",
+            "name": "[parameters('VNETName')]",
             "apiVersion": "2019-04-01",
             "location": "region-A",
             "dependsOn": [
@@ -90,9 +90,9 @@
             ],
             "properties": {
                 "addressSpace": {
-                    "addressPrefixes": "[parameters('addressPrefix')]"
+                    "addressPrefixes": "[Parameters('addressPrefix')]"
                 },
-                "subnets": "[variables('allSubnets')]"
+                "subnets": "[variabLes('AllSubnets')]"
             },
             "tags": {
                 "role": "Networking"
@@ -201,6 +201,7 @@
                         "input": {
                             "name": "[concat('rule-', copyIndex('securityRules', 200))]",
                             "properties": {
+                                "description": "[if(equals('a', 'a'), json('null'), json('null'))]",
                                 "protocol": "Tcp",
                                 "sourcePortRange": "*",
                                 "destinationPortRanges": [


### PR DESCRIPTION
## PR Summary

- Fixed resource segmentation issue when `ResourceType` includes trailing slash. #165
- Fixed expand resource template property as null fails. #167
- Fixed case-sensitivity of variables, parameters and functions. #168

Fixed #165 
Fixed #167 
Fixed #168 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
