### PR TITLE
Pre-release v0.7.0-B1912008

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.7.0-B1912008 (pre-release)
+
 - Fixed null reference without parameters file. [#189](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/189)
 - Added new rule to check presence of classic Co-Administrators. [#188](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/188)
 - Added new rule to check AKS node pool version matches cluster version. [#186](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/186)


### PR DESCRIPTION
## PR Summary

- Fixed null reference without parameters file. #189
- Added new rule to check presence of classic Co-Administrators. #188
- Added new rule to check AKS node pool version matches cluster version. #186
- Added new rule to check AKS clusters use pod security policies. #142
- Added new rule to check AKS clusters use network policies. #143
- Added new rule to check AKS node pools use scale sets. #187
- Added new baseline to include rules for preview features. #190
- Updated `Azure.AKS.Version` to check for node pool version. #191
- **Breaking change**: RBAC rules have been renamed from `Azure.Subscription.*` to `Azure.RBAC.*`. #119
- **Breaking change**: Security Center rules have been renamed from `Azure.Subscription.*` to `Azure.SecureCenter.*`. #119
- **Breaking change**: Renamed default baseline from `Azure.SubscriptionDefault` to `Azure.Default`. #190

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
