### PR TITLE
Fixed missing node pool version fail #198

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed missing cmdlet help. [#196](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/196)
+- Fixed AKS templates without node pool orchestratorVersion fail. [#198](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/198)
 
 ## v0.7.0-B1912008 (pre-release)
 

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -169,8 +169,18 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterA/agentpool3';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterA/agentpool3', 'clusterA/agentpool4';
+        }
+
+        It 'Azure.AKS.PoolVersion' {
+            $filteredResult = $result | Where-Object { $_.RuleName -eq 'Azure.AKS.PoolVersion' };
+
+            # Pass
+            $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'clusterA';
         }
 
         It 'Azure.AKS.PoolScaleSet' {
@@ -185,8 +195,8 @@ Describe 'Azure.AKS' -Tag AKS {
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
-            $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterA/agentpool3';
+            $ruleResult.Length | Should -Be 3;
+            $ruleResult.TargetName | Should -BeIn 'clusterA', 'clusterA/agentpool3', 'clusterA/agentpool4';
         }
     }
 }

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -38,7 +38,6 @@
                         "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-01')]",
                         "maxPods": 50,
                         "type": "VirtualMachineScaleSets",
-                        "orchestratorVersion": "1.14.8",
                         "osType": "Linux"
                     }
                 ],
@@ -113,6 +112,23 @@
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
                 "orchestratorVersion": "1.14.8",
+                "osType": "Linux"
+            }
+        },
+        {
+            "type": "Microsoft.ContainerService/managedClusters/agentPools",
+            "apiVersion": "2019-10-01",
+            "name": "[concat(parameters('clusterName'), '/agentpool4')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.ContainerService/managedClusters', parameters('clusterName'))]"
+            ],
+            "properties": {
+                "count": 3,
+                "vmSize": "Standard_B2ms",
+                "osDiskSizeGB": 100,
+                "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-04')]",
+                "maxPods": 50,
+                "type": "VirtualMachineScaleSets",
                 "osType": "Linux"
             }
         }


### PR DESCRIPTION
## PR Summary

- Fixed AKS templates without node pool orchestratorVersion fail. #198

Fixes #198 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
