### PR TITLE
Pre-release v0.8.0-B2001006

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.0-B2001006 (pre-release)
+
 - Updated documentation to use parent culture `en`. [#224](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/224)
 - Added rules for ARM template and parameter file structure. [#225](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/225)
 - **Breaking change**: Application Gateway rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.AppGW.*`. [#119](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/119)


### PR DESCRIPTION
## PR Summary

- Updated documentation to use parent culture `en`. #224
- Added rules for ARM template and parameter file structure. #225
- **Breaking change**: Application Gateway rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.AppGW.*`. #119
- **Breaking change**: Load balancer rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.LB.*`. #119
- **Breaking change**: NSG rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.NSG.*`. #119
- **Breaking change**: VNET rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.VNET.*`. #119
- **Breaking change**: NIC rules have been renamed from `Azure.VirtualNetwork.*` to `Azure.VM.*`. #119
- **Breaking change**: Renamed storage account rule `Azure.Storage.SecureTransferRequired` to `Azure.Storage.SecureTransfer`. #119

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
