### PR TITLE
Fix Azure.Resource.UseTags filter #230

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Azure.Resource.UseTags` applying to template and parameter files. [#230](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/230)
+
 ## v0.8.0-B2001006 (pre-release)
 
 - Updated documentation to use parent culture `en`. [#224](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/224)

--- a/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.Common.Rule.ps1
@@ -193,7 +193,7 @@ function global:SupportsTags {
     param ()
     process {
         if (
-            ($PSRule.TargetType -eq 'Microsoft.Subscription') -or
+            ($PSRule.TargetType -notlike 'Microsoft.*/*') -or
             ($PSRule.TargetType -like 'Microsoft.Authorization/*') -or
             ($PSRule.TargetType -like 'Microsoft.Billing/*') -or
             ($PSRule.TargetType -like 'Microsoft.Classic*') -or


### PR DESCRIPTION
## PR Summary

- Fix `Azure.Resource.UseTags` applying to template and parameter files. #230

Fixes #230 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
