### PR TITLE
Updated Azure.VNET.UseNSGs for subnets #246 #247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Updated `Azure.VNET.UseNSGs` to apply to subnet resources from templates. [#246](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/246)
+- Updated `Azure.AKS.Version` to 1.15.7. [#247](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/247)
+
 ## v0.8.0-B2001018 (pre-release)
 
 - Fix `Azure.Resource.UseTags` applying to template and parameter files. [#230](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/230)

--- a/src/PSRule.Rules.Azure/en-AU/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en-AU/PSRule-rules.psd1
@@ -7,4 +7,5 @@
     AKSVersion = "The Kubernetes version is v{0}."
     AKSNodePoolType = "The agent pool ({0}) is not using scale sets."
     AKSNodePoolVersion = "The agent pool ({0}) is running v{1}."
+    SubnetNSGNotConfigured = "The subnet ({0}) has no NSG associated."
 }

--- a/src/PSRule.Rules.Azure/en-GB/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en-GB/PSRule-rules.psd1
@@ -7,4 +7,5 @@
     AKSVersion = "The Kubernetes version is v{0}."
     AKSNodePoolType = "The agent pool ({0}) is not using scale sets."
     AKSNodePoolVersion = "The agent pool ({0}) is running v{1}."
+    SubnetNSGNotConfigured = "The subnet ({0}) has no NSG associated."
 }

--- a/src/PSRule.Rules.Azure/en-US/PSRule-rules.psd1
+++ b/src/PSRule.Rules.Azure/en-US/PSRule-rules.psd1
@@ -7,4 +7,5 @@
     AKSVersion = "The Kubernetes version is v{0}."
     AKSNodePoolType = "The agent pool ({0}) is not using scale sets."
     AKSNodePoolVersion = "The agent pool ({0}) is running v{1}."
+    SubnetNSGNotConfigured = "The subnet ({0}) has no NSG associated."
 }

--- a/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
+++ b/src/PSRule.Rules.Azure/rules/Azure.AKS.Rule.ps1
@@ -19,7 +19,7 @@ Rule 'Azure.AKS.Version' -Type 'Microsoft.ContainerService/managedClusters', 'Mi
             (([Version]$TargetObject.Properties.orchestratorVersion) -ge $minVersion)
         Reason ($LocalizedData.AKSVersion -f $TargetObject.Properties.orchestratorVersion);
     }
-} -Configure @{ minAKSVersion = '1.15.5' }
+} -Configure @{ minAKSVersion = '1.15.7' }
 
 # Synopsis: AKS agent pools should run the same Kubernetes version as the cluster
 Rule 'Azure.AKS.PoolVersion' -Type 'Microsoft.ContainerService/managedClusters' -Tag @{ release = 'GA' } {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.AKS.Tests.ps1
@@ -55,13 +55,13 @@ Describe 'Azure.AKS' -Tag AKS {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'cluster-B';
+            $ruleResult.TargetName | Should -BeIn 'cluster-B';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 2;
-            $ruleResult.TargetName | Should -Be 'cluster-A', 'cluster-C';
+            $ruleResult.TargetName | Should -BeIn 'cluster-A', 'cluster-C';
         }
 
         It 'Azure.AKS.PoolVersion' {

--- a/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
+++ b/tests/PSRule.Rules.Azure.Tests/Azure.VirtualNetwork.Tests.ps1
@@ -39,13 +39,14 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 3;
-            $ruleResult.TargetName | Should -Be 'vnet-B', 'vnet-C', 'vnet-D';
+            $ruleResult.TargetName | Should -BeIn 'vnet-B', 'vnet-C', 'vnet-D';
+            $ruleResult.Reason | Should -BeLike 'The subnet (*) has no NSG associated.';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-A';
+            $ruleResult.TargetName | Should -BeIn 'vnet-A';
         }
 
         It 'Azure.VNET.SingleDNS' {
@@ -115,13 +116,16 @@ Describe 'Azure.VNET' -Tag 'Network', 'VNET' {
 
             # Fail
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Fail' });
-            $ruleResult | Should -BeNullOrEmpty;
+            $ruleResult | Should -Not -BeNullOrEmpty;
+            $ruleResult.Length | Should -Be 1;
+            $ruleResult.TargetName | Should -BeIn 'vnet-001/subnet2';
+            $ruleResult.Reason | Should -BeLike 'The subnet (*) has no NSG associated.';
 
             # Pass
             $ruleResult = @($filteredResult | Where-Object { $_.Outcome -eq 'Pass' });
             $ruleResult | Should -Not -BeNullOrEmpty;
             $ruleResult.Length | Should -Be 1;
-            $ruleResult.TargetName | Should -Be 'vnet-001';
+            $ruleResult.TargetName | Should -BeIn 'vnet-001';
         }
 
         It 'Azure.VNET.SingleDNS' {

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.Template.json
@@ -27,7 +27,7 @@
             "name": "[parameters('clusterName')]",
             "location": "[parameters('clusterLocation')]",
             "properties": {
-                "kubernetesVersion": "1.15.5",
+                "kubernetesVersion": "1.15.7",
                 "dnsPrefix": "[concat('npcorp-', parameters('clusterName'))]",
                 "agentPoolProfiles": [
                     {
@@ -111,7 +111,7 @@
                 "vnetSubnetID": "[concat(parameters('vnetId'), '/subnets/subnet-03')]",
                 "maxPods": 50,
                 "type": "VirtualMachineScaleSets",
-                "orchestratorVersion": "1.15.5",
+                "orchestratorVersion": "1.15.7",
                 "osType": "Linux"
             }
         },

--- a/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
+++ b/tests/PSRule.Rules.Azure.Tests/Resources.AKS.json
@@ -6,7 +6,7 @@
         "ResourceName": "cluster-A",
         "Name": "cluster-A",
         "Properties": {
-            "kubernetesVersion": "1.15.5",
+            "kubernetesVersion": "1.15.7",
             "dnsPrefix": "cluster-A",
             "fqdn": "cluster-A-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -18,7 +18,7 @@
                     "vnetSubnetID": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/vnet-A/subnets/subnet-A",
                     "maxPods": 30,
                     "type": "AvailabilitySet",
-                    "orchestratorVersion": "1.15.5",
+                    "orchestratorVersion": "1.15.7",
                     "osType": "Linux"
                 }
             ],
@@ -136,7 +136,7 @@
         "ParentResource": null,
         "Properties": {
             "provisioningState": "Succeeded",
-            "kubernetesVersion": "1.15.5",
+            "kubernetesVersion": "1.15.7",
             "dnsPrefix": "cluster-C",
             "fqdn": "cluster-C-00000000.nnn.region.azmk8s.io",
             "agentPoolProfiles": [
@@ -149,7 +149,7 @@
                     "maxPods": 50,
                     "type": "VirtualMachineScaleSets",
                     "provisioningState": "Succeeded",
-                    "orchestratorVersion": "1.15.5",
+                    "orchestratorVersion": "1.15.7",
                     "osType": "Linux"
                 }
             ],


### PR DESCRIPTION
## PR Summary

- Updated `Azure.VNET.UseNSGs` to apply to subnet resources from templates. #246
- Updated `Azure.AKS.Version` to 1.15.7. #247

Fixes #246 
Fixes #247 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Rule changes**
  - [x] Unit tests created/ updated
  - [x] Rule documentation created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/BernieWhite/PSRule.Rules.Azure/blob/master/CHANGELOG.md) has been updated with change under unreleased section
