### PR TITLE
Pre-release v0.8.0-B2001029

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.8.0-B2001029 (pre-release)
+
 - Updated `Azure.VNET.UseNSGs` to apply to subnet resources from templates. [#246](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/246)
 - Updated `Azure.AKS.Version` to 1.15.7. [#247](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/247)
 - **Breaking change**: Renamed `Azure.File.*` rules to `Azure.Template.*`. [#252](https://github.com/BernieWhite/PSRule.Rules.Azure/issues/252)


### PR DESCRIPTION
## PR Summary

- Updated `Azure.VNET.UseNSGs` to apply to subnet resources from templates. #246
- Updated `Azure.AKS.Version` to 1.15.7. #247
- **Breaking change**: Renamed `Azure.File.*` rules to `Azure.Template.*`. #252

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
